### PR TITLE
Asyncify emscriptenhttp transports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,57 @@
-language: node_js
-dist: focal
-os: linux
-node_js:
-  - 14
+matrix:
+  include:
+    - language: node_js
+      name: "default"
+      dist: focal
+      os: linux
+      node_js:
+        - 14
 
-install:
-  - npm install
-  - sh setup.sh
-  - git clone https://github.com/emscripten-core/emsdk.git
-  - cd emsdk
-  - ./emsdk install latest
-  - ./emsdk activate latest
-  - cd ..
-  - source ./emsdk/emsdk_env.sh
-  - cd emscriptenbuild
-  - ./build.sh
-  - cd ..
+      install:
+        - npm install
+        - sh setup.sh
+        - git clone https://github.com/emscripten-core/emsdk.git
+        - cd emsdk
+        - ./emsdk install latest
+        - ./emsdk activate latest
+        - cd ..
+        - source ./emsdk/emsdk_env.sh
+        - cd emscriptenbuild
+        - ./build.sh
+        - cd ..
+      script:
+      - |
+        set -e
+        npm run test
+        npm run test-browser
+        ./preparepublishnpm.sh  
+        PACKAGEFILE=`npm pack | tail -n 1`
+        tar -xvzf $PACKAGEFILE
+        rm test-browser/lg2.*
+        echo "run browser tests with npm package"
+        cp package/lg2.* test-browser/
+        npm run test-browser
+        
+    - language: node_js
+      name: "asyncify"
+      dist: focal
+      os: linux
+      node_js:
+        - 14
 
-script:
-- |
-  set -e
-  npm run test
-  npm run test-browser
-  ./preparepublishnpm.sh  
-  PACKAGEFILE=`npm pack | tail -n 1`
-  tar -xvzf $PACKAGEFILE
-  rm test-browser/lg2.*
-  echo "run browser tests with npm package"
-  cp package/lg2.* test-browser/
-  npm run test-browser
+      install:
+        - npm install
+        - sh setup.sh
+        - git clone https://github.com/emscripten-core/emsdk.git
+        - cd emsdk
+        - ./emsdk install latest
+        - ./emsdk activate latest
+        - cd ..
+        - source ./emsdk/emsdk_env.sh
+        - cd emscriptenbuild
+        - ./build.sh Release-async
+        - cd ..
+      script:
+      - |
+        set -e
+        npm run test-browser-async

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ You'll start the worker from your html with the tag:
 The example above expects to find a git repository at `http://localhost:5000/test.git`. If you want to clone from github you'd need a proxy running locally because of [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) restrictions that would prevent you
 accessing github directly. For testing you can use the proxy found in [examples/webserverwithgithubproxy.js](examples/webserverwithgithubproxy.js)
 
+# Use in Browser without a WebWorker
+A webworker is more performant but for cases where you really need to work in the browser, the http requests must be asynchronous and not synchronous as in the default builds.
+
+If you use the `emscriptenbuilds/build.sh` you can build `async` versions with:
+```
+./build.sh Release-async
+```
+and
+```
+./build.sh Debug-async
+```
+Note that the compiled output is about twice the size for non-async builds, and that git operations will take place on the main thread which can affect reponsiveness of your web UI.
+
+See below for more details on building using `build.sh`.
 # Use from nodejs with pre built binaries
 
 You may install the npm package containing the binaries:

--- a/emscriptenbuild/build.sh
+++ b/emscriptenbuild/build.sh
@@ -1,13 +1,33 @@
 #!/bin/bash
 
+BUILD_TYPE=Debug
+ASYNCIFY_FLAGS=" -s ASYNCIFY -s 'ASYNCIFY_IMPORTS=[\"emscriptenhttp_do_get\", \"emscriptenhttp_do_read\", \"emscriptenhttp_do_post\"]' "
+POST_JS="--post-js $(pwd)/post.js"
+
+# Reset in case we've done an '-async' build
+cp ../libgit2patchedfiles/src/transports/emscriptenhttp.c ../libgit2/src/transports/emscriptenhttp.c
+
 # Set build type to Release for release
 if [ "$1" == "Release" ]; then
-    BUILD_TYPE=$1
+    BUILD_TYPE=Release
     EXTRA_CMAKE_C_FLAGS="-Oz"
-else
-    BUILD_TYPE=Debug
 fi
 
-emcmake cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="$EXTRA_CMAKE_C_FLAGS --pre-js $(pwd)/pre.js --post-js $(pwd)/post.js -s \"EXTRA_EXPORTED_RUNTIME_METHODS=['FS','callMain']\" -lnodefs.js -lidbfs.js -s INVOKE_RUN=0 -s ALLOW_MEMORY_GROWTH=1" -DREGEX_BACKEND=regcomp -DSONAME=OFF -DUSE_HTTPS=OFF -DBUILD_SHARED_LIBS=OFF -DTHREADSAFE=OFF -DUSE_SSH=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=ON ../libgit2
+# For async transports we overwrite emscripenhttp.c, use post-async.js and change the extra flags
+if [ "$1" == "Release-async" ]; then
+    BUILD_TYPE=Release
+    cp ../libgit2patchedfiles/src/transports/emscriptenhttp-async.c ../libgit2/src/transports/emscriptenhttp.c
+
+    EXTRA_CMAKE_C_FLAGS="-O3 $ASYNCIFY_FLAGS"
+    POST_JS="--post-js $(pwd)/post-async.js"
+elif [ "$1" == "Debug-async" ]; then
+    BUILD_TYPE=Debug
+    cp ../libgit2patchedfiles/src/transports/emscriptenhttp-async.c ../libgit2/src/transports/emscriptenhttp.c
+
+    EXTRA_CMAKE_C_FLAGS="$ASYNCIFY_FLAGS"
+    POST_JS="--post-js $(pwd)/post-async.js"
+fi
+
+emcmake cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="$EXTRA_CMAKE_C_FLAGS  --pre-js $(pwd)/pre.js $POST_JS -s \"EXTRA_EXPORTED_RUNTIME_METHODS=['FS','callMain']\" -lnodefs.js -lidbfs.js -s INVOKE_RUN=0 -s ALLOW_MEMORY_GROWTH=1" -DREGEX_BACKEND=regcomp -DSONAME=OFF -DUSE_HTTPS=OFF -DBUILD_SHARED_LIBS=OFF -DTHREADSAFE=OFF -DUSE_SSH=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=ON ../libgit2
 emcmake cmake -build ../libgit2
 emmake make

--- a/emscriptenbuild/build.sh
+++ b/emscriptenbuild/build.sh
@@ -28,6 +28,9 @@ elif [ "$1" == "Debug-async" ]; then
     POST_JS="--post-js $(pwd)/post-async.js"
 fi
 
+# Before building, remove any ../libgit2/src/transports/emscriptenhttp.c left from running setup.sh 
+[ -f "../libgit2/src/transports/emscriptenhttp-async.c" ] && rm ../libgit2/src/transports/emscriptenhttp-async.c
+
 emcmake cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="$EXTRA_CMAKE_C_FLAGS  --pre-js $(pwd)/pre.js $POST_JS -s \"EXTRA_EXPORTED_RUNTIME_METHODS=['FS','callMain']\" -lnodefs.js -lidbfs.js -s INVOKE_RUN=0 -s ALLOW_MEMORY_GROWTH=1" -DREGEX_BACKEND=regcomp -DSONAME=OFF -DUSE_HTTPS=OFF -DBUILD_SHARED_LIBS=OFF -DTHREADSAFE=OFF -DUSE_SSH=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=ON ../libgit2
 emcmake cmake -build ../libgit2
 emmake make

--- a/emscriptenbuild/post-async.js
+++ b/emscriptenbuild/post-async.js
@@ -25,6 +25,15 @@ FS.chmod = function(path, mode, dontFollow) {
 };
 
 if(ENVIRONMENT_IS_WEB) {
+    Module.oldCallMain = Module.callMain
+    Module.callMain = async (args) => {
+        await Module.oldCallMain(args);
+        var runningAsync = typeof Asyncify === 'object' && Asyncify.currData;
+        if (runningAsync) {
+            await new Promise((resolve) => { Asyncify.asyncFinalizers.push(() => { resolve();}); });
+        }
+    };
+
     Object.assign(Module, {
         emscriptenhttpconnect: async function(url, buffersize, method, headers) {
           let result = new Promise((resolve, reject) => {

--- a/emscriptenbuild/post-async.js
+++ b/emscriptenbuild/post-async.js
@@ -1,0 +1,194 @@
+/**
+ * Javascript functions for emscripten http transport for nodejs and the browser NOT using a webworker
+ * 
+ * If you can't use a webworker, you can build Release-async or Debug-async versions of wasm-git
+ * which use async transports, and can be run without a webworker. The lg2 release files are about
+ * twice the size with this option, and your UI may be affected by doing git operations in the
+ * main JavaScript thread.
+ * 
+ * This the non-webworker version (see also post.js)
+ */
+
+const emscriptenhttpconnections = {};
+let httpConnectionNo = 0;
+
+const chmod = FS.chmod;
+    
+FS.chmod = function(path, mode, dontFollow) { 
+    if (mode === 0o100000 > 0) {
+        // workaround for libgit2 calling chmod with only S_IFREG set (permisions 0000)
+        // reason currently not known
+        return chmod(path, mode, dontFollow);
+    } else {
+        return 0;
+    }
+};
+
+if(ENVIRONMENT_IS_WEB) {
+    Object.assign(Module, {
+        emscriptenhttpconnect: async function(url, buffersize, method, headers) {
+          let result = new Promise((resolve, reject) => {
+            if(!method) {
+              method = 'GET';
+            }
+
+            const xhr = new XMLHttpRequest();
+            xhr.open(method, url, true);
+            xhr.responseType = 'arraybuffer';
+
+            if (headers) {
+                Object.keys(headers).forEach(header => xhr.setRequestHeader(header, headers[header]));
+            }
+
+            emscriptenhttpconnections[httpConnectionNo] = {
+                xhr: xhr,
+                resultbufferpointer: 0,
+                buffersize: buffersize
+            };
+            
+            if(method === 'GET') {
+              xhr.onload = function () {
+                resolve(httpConnectionNo++);
+              };
+              xhr.send();
+            } else {
+              resolve(httpConnectionNo++);
+            }
+          });
+          return result;
+        },
+        emscriptenhttpwrite: function(connectionNo, buffer, length) {
+            const connection = emscriptenhttpconnections[connectionNo];
+            const buf = new Uint8Array(Module.HEAPU8.buffer,buffer,length).slice(0);
+            if(!connection.content) {
+                connection.content = buf;
+            } else {
+                const content = new Uint8Array(connection.content.length + buf.length);
+                content.set(connection.content);
+                content.set(buf, connection.content.length);
+                connection.content = content;
+            }            
+        },
+        emscriptenhttpread: async function(connectionNo, buffer, buffersize) {
+          const connection = emscriptenhttpconnections[connectionNo];
+
+          function handleResponse(connection, buffer, buffersize) {
+            let bytes_read = connection.xhr.response.byteLength - connection.resultbufferpointer;
+            if (bytes_read > buffersize) {
+              bytes_read = buffersize;
+            }
+            const responseChunk = new Uint8Array(connection.xhr.response, connection.resultbufferpointer, bytes_read);
+            writeArrayToMemory(responseChunk, buffer);
+            connection.resultbufferpointer += bytes_read;
+            return bytes_read;
+          }
+
+          let result = new Promise((resolve) => {
+              if(connection.content) {
+                    connection.xhr.onload = function () {
+                    resolve(handleResponse(connection, buffer, buffersize));
+                };
+                connection.xhr.send(connection.content.buffer);
+                connection.content = null;
+              } else {
+                resolve(handleResponse(connection, buffer, buffersize));
+              }
+          });
+
+          return result;
+        },
+        emscriptenhttpfree: function(connectionNo) {
+            delete emscriptenhttpconnections[connectionNo];
+        }
+    });
+} else if(ENVIRONMENT_IS_NODE) {
+    const { Worker } = require('worker_threads');
+
+    Object.assign(Module, {
+        emscriptenhttpconnect: function(url, buffersize, method, headers) {
+            const statusArray = new Int32Array(new SharedArrayBuffer(4));
+            Atomics.store(statusArray, 0, method === 'POST' ? -1 : 0);
+        
+            const resultBuffer = new SharedArrayBuffer(buffersize);
+            const resultArray = new Uint8Array(resultBuffer);
+            const workerData =  {
+                    statusArray: statusArray,
+                    resultArray: resultArray,
+                    url: url,
+                    method: method ? method: 'GET',
+                    headers: headers
+            };  
+
+            new Worker('(' + (function requestWorker() {
+                const { workerData } = require('worker_threads');
+                const req = require(workerData.url.indexOf('https') === 0 ? 'https' : 'http')
+                              .request(workerData.url, {
+                    headers: workerData.headers,
+                    method: workerData.method
+                }, (res) => {
+                    res.on('data', chunk => {
+                        const previousStatus = workerData.statusArray[0];
+                        if(previousStatus !== 0) {
+                            Atomics.wait(workerData.statusArray, 0, previousStatus);
+                        }                    
+                        workerData.resultArray.set(chunk);                    
+                        Atomics.store(workerData.statusArray, 0, chunk.length);
+                        Atomics.notify(workerData.statusArray, 0, 1);
+                    });
+                });        
+
+                if(workerData.method === 'POST') {
+                    while(workerData.statusArray[0] !== 0) {
+                        Atomics.wait(workerData.statusArray, 0, -1);
+                        const length = workerData.statusArray[0];
+                        if(length === 0) {
+                            break;
+                        }
+                        req.write(Buffer.from(workerData.resultArray.slice(0, length)));
+                        Atomics.store(workerData.statusArray, 0, -1);
+                        Atomics.notify(workerData.statusArray, 0, 1);
+                    }
+                }
+                
+                req.end();
+            }).toString()+')()' , {
+                eval: true,
+                workerData: workerData
+            }); 
+            emscriptenhttpconnections[httpConnectionNo] = workerData;
+            console.log('connected with method', workerData.method, 'to', workerData.url);
+            return httpConnectionNo++;
+        },
+        emscriptenhttpwrite: function(connectionNo, buffer, length) {
+            const connection = emscriptenhttpconnections[connectionNo];
+            connection.resultArray.set(new Uint8Array(Module.HEAPU8.buffer,buffer,length));
+            Atomics.store(connection.statusArray, 0, length);
+            Atomics.notify(connection.statusArray, 0, 1);
+            // Wait for write to finish
+            Atomics.wait(connection.statusArray, 0, length);
+        },
+        emscriptenhttpread: function(connectionNo, buffer) { 
+            const connection = emscriptenhttpconnections[connectionNo];
+
+            if(connection.statusArray[0] === -1 && connection.method === 'POST') {
+                // Stop writing
+                Atomics.store(connection.statusArray, 0, 0);
+                Atomics.notify(connection.statusArray, 0, 1);
+            }
+            Atomics.wait(connection.statusArray, 0, 0);
+            const bytes_read = connection.statusArray[0];
+
+            writeArrayToMemory(connection.resultArray.slice(0, bytes_read), buffer);
+
+            //console.log('read with connectionNo', connectionNo, 'length', bytes_read, 'content',
+            //        new TextDecoder('utf-8').decode(connection.resultArray.slice(0, bytes_read)));
+            Atomics.store(connection.statusArray, 0, 0);
+            Atomics.notify(connection.statusArray, 0, 1);
+
+            return bytes_read;
+        },
+        emscriptenhttpfree: function(connectionNo) {
+            delete emscriptenhttpconnections[connectionNo];
+        }
+    });
+}

--- a/emscriptenbuild/post.js
+++ b/emscriptenbuild/post.js
@@ -1,5 +1,12 @@
 /**
- * Javascript functions for emscripten http transport for nodejs and the browser
+ * Javascript functions for emscripten http transport for nodejs and the browser using a webworker
+ * 
+ * If you can't use a webworker, you can build Release-async or Debug-async versions of wasm-git
+ * which use async transports, and can be run without a webworker. The lg2 release files are about
+ * twice the size with this option, and your UI may be affected by doing git operations in the
+ * main JavaScript thread.
+ * 
+ * This the non-webworker version (see also post-async.js)
  */
 
 const emscriptenhttpconnections = {};

--- a/karma.conf-async.js
+++ b/karma.conf-async.js
@@ -1,0 +1,74 @@
+// Karma configuration
+// Generated on Sun May 10 2020 17:41:31 GMT+0200 (sentraleuropeisk sommertid)
+const gitserver = require('./test-browser/githttpserver.js');
+gitserver.startServer();
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: 'test-browser-async',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      {pattern: 'lg2.*', included: false},
+    //   {pattern: 'async-test.js', included: false},
+      {pattern: '**/*.spec.js'}
+    ],
+
+    // list of files / patterns to exclude
+    exclude: [
+    ],
+
+    proxies: {
+      '/testrepo.git': 'http://localhost:5000/testrepo.git',
+    },
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/libgit2patchedfiles/src/transports/emscriptenhttp-async.c
+++ b/libgit2patchedfiles/src/transports/emscriptenhttp-async.c
@@ -1,0 +1,185 @@
+#ifdef __EMSCRIPTEN__
+
+#include "common.h"
+#include "emscripten.h"
+#include "git2/transport.h"
+#include "smart.h"
+
+static const char *upload_pack_ls_service_url = "/info/refs?service=git-upload-pack";
+static const char *upload_pack_service_url = "/git-upload-pack";
+static const char *receive_pack_ls_service_url = "/info/refs?service=git-receive-pack";
+static const char *receive_pack_service_url = "/git-receive-pack";
+
+typedef struct {
+	git_smart_subtransport_stream parent;
+    const char *service_url;
+	int connectionNo;
+} emscriptenhttp_stream;
+
+typedef struct {
+	git_smart_subtransport parent;
+	transport_smart *owner;
+
+} emscriptenhttp_subtransport;
+
+// Asyncified functions wrap async transports for browser when not using a webworker
+
+EM_JS(int, emscriptenhttp_do_get, (const char* url, size_t buf_size), {
+	return Asyncify.handleAsync(async () => {
+		const urlString = UTF8ToString(url);
+		return await Module.emscriptenhttpconnect(urlString, buf_size);
+	});
+});
+
+EM_JS(int, emscriptenhttp_do_post, (const char* url, size_t buf_size), {
+	return Asyncify.handleAsync(async () => {
+		const urlString = UTF8ToString(url);
+		return await Module.emscriptenhttpconnect(urlString, buf_size, 'POST', {
+			'Content-Type': urlString.indexOf('git-upload-pack') > 0 ? 
+				'application/x-git-upload-pack-request' :
+				'application/x-git-receive-pack-request'
+			});
+	});
+});
+
+EM_JS(size_t, emscriptenhttp_do_read, (int connectionNo, char* buffer, size_t buf_size), {
+	return Asyncify.handleAsync(async () => {
+		return await Module.emscriptenhttpread(connectionNo, buffer, buf_size);
+	});
+});
+
+static void emscriptenhttp_stream_free(git_smart_subtransport_stream *stream)
+{
+	emscriptenhttp_stream *s = (emscriptenhttp_stream *)stream;
+
+	git__free(s);
+}
+
+static int emscriptenhttp_stream_read(
+	git_smart_subtransport_stream *stream,
+	char *buffer,
+	size_t buf_size,
+	size_t *bytes_read)
+{
+    emscriptenhttp_stream *s = (emscriptenhttp_stream *)stream;
+
+	if(s->connectionNo == -1) {
+		s->connectionNo = emscriptenhttp_do_get(s->service_url, DEFAULT_BUFSIZE);
+	}
+
+	*bytes_read = emscriptenhttp_do_read(s->connectionNo, buffer, buf_size);
+
+    return 0;
+}
+
+static int emscriptenhttp_stream_write_single(
+	git_smart_subtransport_stream *stream,
+	const char *buffer,
+	size_t len)
+{
+    emscriptenhttp_stream *s = (emscriptenhttp_stream *)stream;
+    
+	if(s->connectionNo == -1) {
+		s->connectionNo = emscriptenhttp_do_post(s->service_url, DEFAULT_BUFSIZE);
+	}
+
+   EM_ASM({
+		return Module.emscriptenhttpwrite($0, $1, $2);
+    }, s->connectionNo, buffer, len);
+
+    return 0;
+}
+
+static int emscriptenhttp_stream_alloc(emscriptenhttp_subtransport *t, emscriptenhttp_stream **stream)
+{
+	emscriptenhttp_stream *s;
+
+	if (!stream)
+		return -1;
+
+	s = git__calloc(1, sizeof(emscriptenhttp_stream));
+	GIT_ERROR_CHECK_ALLOC(s);
+
+	s->parent.subtransport = &t->parent;
+	s->parent.read = emscriptenhttp_stream_read;
+	s->parent.write = emscriptenhttp_stream_write_single;
+	s->parent.free = emscriptenhttp_stream_free;
+	s->connectionNo = -1;
+
+	*stream = s;
+
+	return 0;
+}
+
+static int emscriptenhttp_action(
+	git_smart_subtransport_stream **stream,
+	git_smart_subtransport *subtransport,
+	const char *url,
+	git_smart_service_t action)
+{
+    emscriptenhttp_subtransport *t = (emscriptenhttp_subtransport *)subtransport;
+	emscriptenhttp_stream *s;
+	
+    if (emscriptenhttp_stream_alloc(t, &s) < 0)
+		return -1;
+
+    git_buf buf = GIT_BUF_INIT;
+    
+    switch(action) {
+        case GIT_SERVICE_UPLOADPACK_LS:
+            git_buf_printf(&buf, "%s%s", url, upload_pack_ls_service_url);   
+
+            break;
+        case GIT_SERVICE_UPLOADPACK:
+            git_buf_printf(&buf, "%s%s", url, upload_pack_service_url);
+            break;
+        case GIT_SERVICE_RECEIVEPACK_LS:
+            git_buf_printf(&buf, "%s%s", url, receive_pack_ls_service_url);
+            break;
+        case GIT_SERVICE_RECEIVEPACK:
+            git_buf_printf(&buf, "%s%s", url, receive_pack_service_url);
+            break;            
+    }
+
+    s->service_url = git_buf_cstr(&buf);
+    *stream = &s->parent;
+
+    return 0;
+}
+
+static int emscriptenhttp_close(git_smart_subtransport *subtransport)
+{	
+	return 0;
+}
+
+static void emscriptenhttp_free(git_smart_subtransport *subtransport)
+{
+	emscriptenhttp_subtransport *t = (emscriptenhttp_subtransport *)subtransport;
+
+	emscriptenhttp_close(subtransport);
+
+	git__free(t);
+}
+
+int git_smart_subtransport_http(git_smart_subtransport **out, git_transport *owner, void *param) {
+    emscriptenhttp_subtransport *t;
+
+	GIT_UNUSED(param);
+
+	if (!out)
+		return -1;
+
+	t = git__calloc(1, sizeof(emscriptenhttp_subtransport));
+	GIT_ERROR_CHECK_ALLOC(t);
+
+	t->owner = (transport_smart *)owner;
+	t->parent.action = emscriptenhttp_action;
+	t->parent.close = emscriptenhttp_close;
+	t->parent.free = emscriptenhttp_free;
+
+	*out = (git_smart_subtransport *) t;
+
+    return 0;
+}
+
+#endif /* __EMSCRIPTEN__ */

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     ],
     "scripts": {
         "test": "mocha test/**/*.spec.js",
-        "test-browser": "karma start --single-run --browsers ChromeHeadless karma.conf.js"
+        "test-browser": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
+        "test-browser-async": "karma start --single-run --browsers ChromeHeadless karma.conf-async.js"
     },
     "devDependencies": {
         "cgi": "^0.3.1",

--- a/test-browser-async/lg2.js
+++ b/test-browser-async/lg2.js
@@ -1,0 +1,1 @@
+../emscriptenbuild/examples/lg2.js

--- a/test-browser-async/lg2.wasm
+++ b/test-browser-async/lg2.wasm
@@ -1,0 +1,1 @@
+../emscriptenbuild/examples/lg2.wasm

--- a/test-browser-async/test.spec.js
+++ b/test-browser-async/test.spec.js
@@ -1,0 +1,108 @@
+describe('wasm-git', function() {
+    it('should have window', () => {
+        assert(window !== undefined);
+    });
+
+    before((done) => {
+        window.lg2Ready = false;
+        const scriptElement = document.createElement('script');
+        window.Module = {};
+        window.Module.onRuntimeInitialized = () => {
+            window.lg2 = window.Module;
+            window.lg2Ready = true;
+            done();
+        }
+        scriptElement.src = 'base/lg2.js';
+        document.documentElement.appendChild(scriptElement);
+    });
+
+    let lg, FS;
+    it('should have an initialised window.lg2 object', () => {
+        lg = window.lg2;
+        FS = lg.FS;
+        assert(typeof(window.lg2) === 'object' );
+    });
+
+    let APPFS;
+    it('should create an in memory filesystem, APPFS', () => {
+        APPFS = FS.filesystems.MEMFS;
+        assert(typeof(APPFS) === 'object' );
+    });
+    
+    it('should make a working directory', () => {
+        FS.mkdir(workingDir);
+    });
+    
+    it('should mount the filesystem on the working directory', () => {
+        FS.mount(APPFS, { root: '.' }, workingDir);
+    });
+    
+    it('should make a directory and mount a memory filesystem on it', () => {
+        FS.chdir(workingDir);    
+    });
+    
+    it('should write a .gitconfig file', () => {
+        FS.writeFile('/home/web_user/.gitconfig', '[user]\n' +
+                    'name = Test User\n' +
+                    'email = test@example.com');
+    });
+
+    it('should ping the gitserver', async () => {
+        const result = await fetch('/testrepo.git/ping').then(res => res.text());
+        assert(result === 'pong');
+    });
+
+    let workingDir, url, currentRepoRootDir, testFile, testContents;
+    beforeEach(() => {
+        workingDir = "/working";
+        url = `${location.origin}/testrepo.git`;
+        currentRepoRootDir = url.substring(url.lastIndexOf('/') + 1);
+        testFile = "test.txt";
+        testContents = "hello-world!";
+    });
+
+    it('should clone a bare repository and push commits', async () => {
+        console.log(`git clone ${url}`);
+        await lg.callMain(['clone', url, currentRepoRootDir]);
+        FS.chdir(currentRepoRootDir);
+
+        let dircontents = FS.readdir('.');
+        console.log(dircontents);
+        assert(dircontents.length > 2);
+        assert(dircontents.find(entry => entry === '.git'));
+
+        FS.writeFile(testFile, testContents);
+        await lg.callMain(['add', '--verbose', testFile]);
+        await lg.callMain(['commit','-m', `edited ${testFile}`]);
+        await lg.callMain(['push']);
+
+        dircontents = FS.readdir('.');
+        console.log(dircontents);
+        assert(dircontents.length > 2);
+        assert(dircontents.find(entry => entry === testFile));
+    });
+
+    it('rename the local clone of the repository', async () => {
+        FS.chdir(workingDir);
+        FS.rename(currentRepoRootDir, 'junk');
+        dircontents = FS.readdir('.');
+        assert(dircontents.find(entry => entry !== currentRepoRootDir));
+        console.log(`renamed ${currentRepoRootDir}`);
+    });
+
+    it('should clone the repository with contents', async () => {
+        dircontents = FS.readdir('.');
+        assert(dircontents.find(entry => entry !== testFile));
+
+        await lg.callMain(['clone', url, currentRepoRootDir]);
+        dircontents = FS.readdir(currentRepoRootDir);
+        assert(dircontents.length > 2);
+        assert(dircontents.find(entry => entry === '.git'));
+        assert(dircontents.find(entry => entry === testFile));
+
+        console.log(`${currentRepoRootDir}/${testFile}`)
+        const filecontents = FS.readFile(`${currentRepoRootDir}/${testFile}`, {encoding: 'utf8'});
+        console.log('contents:', filecontents);
+        assert(String(filecontents) === testContents);
+    });
+});


### PR DESCRIPTION
It took me a while to figure out how get the mocha tests to wait for the `Module.onRuntimeInitialized()`, but I've now added a test (`npm run test-browser-async`) very similar to the you created for a webworker. To use it you will first need to build with `./build.sh Debug-async` or `./build.sh Release-async`).

I haven't squashed the commit history as it is very clean, but I believe you can do this when merging (at least on github) if you need it. Let me know if that's not what you need.

Thanks very much for your help in getting this far. I'm still looking at options, but it is good to know I have one in `wasm-git` that should cover all my project's needs for the short to medium term.