### PR TITLE
Draft: update test runner and pin Ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   detectonly:
     name: Detect use of .only
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Detect use of .only
@@ -16,7 +16,7 @@ jobs:
           exit 0
   default:
     name: "Default"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Default
@@ -39,7 +39,7 @@ jobs:
           npm run test-browser
   asyncify:
     name: Asyncify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Default

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   default:
     name: "Default"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
             "name": "wasm-git",
             "version": "0.0.13",
             "devDependencies": {
-                "@web/test-runner": "^0.18.2",
-                "@web/test-runner-playwright": "^0.11.0",
+                "@web/test-runner": "^0.20.2",
+                "@web/test-runner-playwright": "^0.11.1",
                 "cgi": "^0.3.1",
                 "chai": "^4.3.7",
                 "mocha": "^10.2.0"
@@ -206,19 +206,19 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
-            "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
+            "version": "2.10.6",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+            "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.4.0",
-                "semver": "7.6.0",
-                "tar-fs": "3.0.5",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "debug": "^4.4.1",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.5.0",
+                "semver": "^7.7.2",
+                "tar-fs": "^3.1.0",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
@@ -232,6 +232,7 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -241,31 +242,22 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "node_modules/@puppeteer/browsers/node_modules/debug": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "yallist": "^4.0.0"
+                "ms": "^2.1.3"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
+                "node": ">=6.0"
             },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/yargs": {
@@ -273,6 +265,7 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -291,6 +284,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
@@ -554,7 +548,8 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/accepts": {
             "version": "1.3.7",
@@ -807,6 +802,7 @@
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@types/node": "*"
@@ -922,15 +918,16 @@
             }
         },
         "node_modules/@web/test-runner": {
-            "version": "0.18.2",
-            "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.18.2.tgz",
-            "integrity": "sha512-jA+957ic31aG/f1mr1b+HYzf/uTu4QsvFhyVgTKi2s5YQYGBbtfzx9PnYi47MVC9K9OHRbW8cq2Urds9qwSU3w==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.20.2.tgz",
+            "integrity": "sha512-zfEGYEDnS0EI8qgoWFjmtkIXhqP15W40NW3dCaKtbxj5eU0a7E53f3GV/tZGD0GlZKF8d4Fyw+AFrwOJU9Z4GA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@web/browser-logs": "^0.4.0",
                 "@web/config-loader": "^0.3.0",
                 "@web/dev-server": "^0.4.0",
-                "@web/test-runner-chrome": "^0.16.0",
+                "@web/test-runner-chrome": "^0.18.1",
                 "@web/test-runner-commands": "^0.9.0",
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-mocha": "^0.9.0",
@@ -953,16 +950,16 @@
             }
         },
         "node_modules/@web/test-runner-chrome": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.16.0.tgz",
-            "integrity": "sha512-Edc6Y49aVB6k18S5IOj9OCX3rEf8F3jptIu0p95+imqxmcutFEh1GNmlAk2bQGnXS0U6uVY7Xbf61fiaXUQqhg==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.18.1.tgz",
+            "integrity": "sha512-eO6ctCaqSguGM6G3cFobGHnrEs9wlv9Juj/Akyr4XLjeEMTheNULdvOXw9Bygi+QC/ir/0snMmt+/YKnfy8rYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-coverage-v8": "^0.8.0",
-                "async-mutex": "0.4.0",
                 "chrome-launcher": "^0.15.0",
-                "puppeteer-core": "^22.0.0"
+                "puppeteer-core": "^24.0.0"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -1047,14 +1044,15 @@
             }
         },
         "node_modules/@web/test-runner-playwright": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
-            "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.1.tgz",
+            "integrity": "sha512-l9tmX0LtBqMaKAApS4WshpB87A/M8sOHZyfCobSGuYqnREgz5rqQpX314yx+4fwHXLLTa5N64mTrawsYkLjliw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-coverage-v8": "^0.8.0",
-                "playwright": "^1.22.2"
+                "playwright": "^1.53.0"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -1074,13 +1072,11 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -1184,6 +1180,7 @@
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -1209,20 +1206,12 @@
                 "lodash": "^4.17.14"
             }
         },
-        "node_modules/async-mutex": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-            "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/b4a": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-            "dev": true
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/balanced-match": {
             "version": "1.0.0",
@@ -1231,76 +1220,88 @@
             "dev": true
         },
         "node_modules/bare-events": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-            "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+            "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-            "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
+            "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^1.0.0"
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
             }
         },
         "node_modules/bare-os": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-            "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+            "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "dev": true,
-            "optional": true
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "bare": ">=1.14.0"
+            }
         },
         "node_modules/bare-path": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.2.tgz",
-            "integrity": "sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "bare-os": "^2.1.0"
+                "bare-os": "^3.0.1"
             }
         },
         "node_modules/bare-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-            "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+            "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "streamx": "^2.16.1"
-            }
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
+                "streamx": "^2.21.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
                 },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
+                "bare-events": {
+                    "optional": true
                 }
-            ]
+            }
         },
         "node_modules/basic-ftp": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
             "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -1342,35 +1343,12 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "*"
             }
@@ -1596,6 +1574,7 @@
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
             "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "*",
                 "escape-string-regexp": "^4.0.0",
@@ -1610,14 +1589,14 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
-            "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.3.1.tgz",
+            "integrity": "sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.22.4"
+                "mitt": "^3.0.1",
+                "zod": "^3.24.1"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -1794,6 +1773,7 @@
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -1897,6 +1877,7 @@
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -1941,10 +1922,11 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1286932",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
-            "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
-            "dev": true
+            "version": "0.0.1475386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
+            "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "5.0.0",
@@ -1989,10 +1971,11 @@
             }
         },
         "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -2062,6 +2045,7 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -2083,6 +2067,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2093,6 +2078,7 @@
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -2106,6 +2092,7 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
             }
@@ -2121,6 +2108,7 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2139,6 +2127,7 @@
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
@@ -2159,6 +2148,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
             "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0"
             },
@@ -2173,7 +2163,8 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -2205,6 +2196,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
             }
@@ -2265,20 +2257,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -2360,15 +2338,15 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
@@ -2437,12 +2415,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -2588,6 +2560,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -2597,12 +2570,13 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -2620,26 +2594,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/ignore": {
             "version": "5.3.1",
@@ -2682,14 +2636,11 @@
             "dev": true
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
             "dev": true,
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">= 12"
             }
@@ -2931,24 +2882,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true
-        },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
         "node_modules/keygrip": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -3064,6 +2997,7 @@
             "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
             "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "debug": "^2.6.9",
                 "marky": "^1.2.2"
@@ -3074,6 +3008,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
@@ -3082,7 +3017,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -3199,10 +3135,11 @@
             }
         },
         "node_modules/marky": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-            "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
-            "dev": true
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+            "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -3290,7 +3227,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
@@ -3403,6 +3341,7 @@
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -3515,19 +3454,20 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
+                "https-proxy-agent": "^7.0.6",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -3538,6 +3478,7 @@
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -3607,7 +3548,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.0.1",
@@ -3628,33 +3570,35 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-            "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+            "version": "1.54.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+            "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.44.0"
+                "playwright-core": "1.54.2"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-            "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+            "version": "1.54.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+            "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/portfinder": {
@@ -3697,24 +3641,26 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
+                "pac-proxy-agent": "^7.1.0",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -3725,6 +3671,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
@@ -3733,13 +3680,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -3755,26 +3704,47 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "22.9.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
-            "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
+            "version": "24.16.2",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.2.tgz",
+            "integrity": "sha512-areKSSQzpoHa5nCk3uD/o504yjrW5ws0N6jZfdFZ3a4H+Q7NBgvuDydjN5P87jN4Rj+eIpLcK3ELOThTtYuuxg==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.2.3",
-                "chromium-bidi": "0.5.19",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1286932",
-                "ws": "8.17.0"
+                "@puppeteer/browsers": "2.10.6",
+                "chromium-bidi": "7.3.1",
+                "debug": "^4.4.1",
+                "devtools-protocol": "0.0.1475386",
+                "typed-query-selector": "^2.12.0",
+                "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+        "node_modules/puppeteer-core/node_modules/debug": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -3825,12 +3795,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/queue-tick": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-            "dev": true
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -4076,10 +4040,11 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4174,18 +4139,20 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
             }
         },
         "node_modules/socks": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -4194,14 +4161,15 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.1.1",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -4215,12 +4183,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true
         },
         "node_modules/statuses": {
             "version": "1.5.0",
@@ -4250,13 +4212,14 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
             },
             "optionalDependencies": {
                 "bare-events": "^2.2.0"
@@ -4367,17 +4330,18 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-            "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             },
             "optionalDependencies": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0"
+                "bare-fs": "^4.0.1",
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/tar-stream": {
@@ -4385,17 +4349,22 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
             }
         },
-        "node_modules/through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true
+        "node_modules/text-decoder": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "b4a": "^1.6.4"
+            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -4431,10 +4400,11 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/tsscmp": {
             "version": "1.0.6",
@@ -4479,6 +4449,13 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/typed-query-selector": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/typical": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -4488,30 +4465,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
-        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -4521,12 +4479,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/urlpattern-polyfill": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.2.0",
@@ -4641,12 +4593,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
         "node_modules/yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -4694,6 +4640,7 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -4721,10 +4668,11 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.22.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -4884,19 +4832,18 @@
             }
         },
         "@puppeteer/browsers": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
-            "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
+            "version": "2.10.6",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+            "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
             "dev": true,
             "requires": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.4.0",
-                "semver": "7.6.0",
-                "tar-fs": "3.0.5",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
+                "debug": "^4.4.1",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.5.0",
+                "semver": "^7.7.2",
+                "tar-fs": "^3.1.0",
+                "yargs": "^17.7.2"
             },
             "dependencies": {
                 "cliui": {
@@ -4910,22 +4857,13 @@
                         "wrap-ansi": "^7.0.0"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                "debug": {
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+                    "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
                     "dev": true,
                     "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-                    "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
+                        "ms": "^2.1.3"
                     }
                 },
                 "yargs": {
@@ -5438,15 +5376,15 @@
             }
         },
         "@web/test-runner": {
-            "version": "0.18.2",
-            "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.18.2.tgz",
-            "integrity": "sha512-jA+957ic31aG/f1mr1b+HYzf/uTu4QsvFhyVgTKi2s5YQYGBbtfzx9PnYi47MVC9K9OHRbW8cq2Urds9qwSU3w==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.20.2.tgz",
+            "integrity": "sha512-zfEGYEDnS0EI8qgoWFjmtkIXhqP15W40NW3dCaKtbxj5eU0a7E53f3GV/tZGD0GlZKF8d4Fyw+AFrwOJU9Z4GA==",
             "dev": true,
             "requires": {
                 "@web/browser-logs": "^0.4.0",
                 "@web/config-loader": "^0.3.0",
                 "@web/dev-server": "^0.4.0",
-                "@web/test-runner-chrome": "^0.16.0",
+                "@web/test-runner-chrome": "^0.18.1",
                 "@web/test-runner-commands": "^0.9.0",
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-mocha": "^0.9.0",
@@ -5462,16 +5400,15 @@
             }
         },
         "@web/test-runner-chrome": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.16.0.tgz",
-            "integrity": "sha512-Edc6Y49aVB6k18S5IOj9OCX3rEf8F3jptIu0p95+imqxmcutFEh1GNmlAk2bQGnXS0U6uVY7Xbf61fiaXUQqhg==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.18.1.tgz",
+            "integrity": "sha512-eO6ctCaqSguGM6G3cFobGHnrEs9wlv9Juj/Akyr4XLjeEMTheNULdvOXw9Bygi+QC/ir/0snMmt+/YKnfy8rYA==",
             "dev": true,
             "requires": {
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-coverage-v8": "^0.8.0",
-                "async-mutex": "0.4.0",
                 "chrome-launcher": "^0.15.0",
-                "puppeteer-core": "^22.0.0"
+                "puppeteer-core": "^24.0.0"
             }
         },
         "@web/test-runner-commands": {
@@ -5541,14 +5478,14 @@
             }
         },
         "@web/test-runner-playwright": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
-            "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.1.tgz",
+            "integrity": "sha512-l9tmX0LtBqMaKAApS4WshpB87A/M8sOHZyfCobSGuYqnREgz5rqQpX314yx+4fwHXLLTa5N64mTrawsYkLjliw==",
             "dev": true,
             "requires": {
                 "@web/test-runner-core": "^0.13.0",
                 "@web/test-runner-coverage-v8": "^0.8.0",
-                "playwright": "^1.22.2"
+                "playwright": "^1.53.0"
             }
         },
         "accepts": {
@@ -5562,13 +5499,10 @@
             }
         },
         "agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.3.4"
-            }
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -5658,19 +5592,10 @@
                 "lodash": "^4.17.14"
             }
         },
-        "async-mutex": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-            "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^2.4.0"
-            }
-        },
         "b4a": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
             "dev": true
         },
         "balanced-match": {
@@ -5680,56 +5605,50 @@
             "dev": true
         },
         "bare-events": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-            "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+            "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
             "dev": true,
             "optional": true
         },
         "bare-fs": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-            "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
+            "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
             "dev": true,
             "optional": true,
             "requires": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^1.0.0"
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4"
             }
         },
         "bare-os": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-            "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+            "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "dev": true,
             "optional": true
         },
         "bare-path": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.2.tgz",
-            "integrity": "sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "bare-os": "^2.1.0"
+                "bare-os": "^3.0.1"
             }
         },
         "bare-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-            "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+            "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
             "dev": true,
             "optional": true,
             "requires": {
-                "streamx": "^2.16.1"
+                "streamx": "^2.21.0"
             }
-        },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
         },
         "basic-ftp": {
             "version": "5.0.5",
@@ -5767,16 +5686,6 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
-        },
-        "buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
         },
         "buffer-crc32": {
             "version": "0.2.13",
@@ -5955,14 +5864,13 @@
             }
         },
         "chromium-bidi": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
-            "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.3.1.tgz",
+            "integrity": "sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==",
             "dev": true,
             "requires": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.22.4"
+                "mitt": "^3.0.1",
+                "zod": "^3.24.1"
             }
         },
         "cli-cursor": {
@@ -6208,9 +6116,9 @@
             "dev": true
         },
         "devtools-protocol": {
-            "version": "0.0.1286932",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
-            "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA==",
+            "version": "0.0.1475386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
+            "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
             "dev": true
         },
         "diff": {
@@ -6247,9 +6155,9 @@
             "dev": true
         },
         "end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "dev": true,
             "requires": {
                 "once": "^1.4.0"
@@ -6451,17 +6359,6 @@
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true
         },
-        "fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6513,15 +6410,14 @@
             "dev": true
         },
         "get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "dev": true,
             "requires": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
+                "debug": "^4.3.4"
             }
         },
         "glob": {
@@ -6569,12 +6465,6 @@
             "requires": {
                 "get-intrinsic": "^1.1.3"
             }
-        },
-        "graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
         },
         "has-flag": {
             "version": "4.0.0",
@@ -6686,12 +6576,12 @@
             }
         },
         "https-proxy-agent": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "requires": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             }
         },
@@ -6703,12 +6593,6 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
-        },
-        "ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
         },
         "ignore": {
             "version": "5.3.1",
@@ -6745,14 +6629,10 @@
             "dev": true
         },
         "ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-            "dev": true,
-            "requires": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            }
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "dev": true
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -6913,22 +6793,6 @@
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
-            }
-        },
-        "jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true
-        },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
             }
         },
         "keygrip": {
@@ -7142,9 +7006,9 @@
             }
         },
         "marky": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-            "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+            "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
             "dev": true
         },
         "media-typer": {
@@ -7371,19 +7235,19 @@
             }
         },
         "pac-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "dev": true,
             "requires": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.2",
-                "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.2"
+                "https-proxy-agent": "^7.0.6",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.5"
             }
         },
         "pac-resolver": {
@@ -7457,19 +7321,19 @@
             "dev": true
         },
         "playwright": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-            "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+            "version": "1.54.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+            "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2",
-                "playwright-core": "1.44.0"
+                "playwright-core": "1.54.2"
             }
         },
         "playwright-core": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-            "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+            "version": "1.54.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+            "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
             "dev": true
         },
         "portfinder": {
@@ -7510,19 +7374,19 @@
             "dev": true
         },
         "proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "dev": true,
             "requires": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
+                "pac-proxy-agent": "^7.1.0",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.5"
             },
             "dependencies": {
                 "lru-cache": {
@@ -7540,9 +7404,9 @@
             "dev": true
         },
         "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
@@ -7556,22 +7420,32 @@
             "dev": true
         },
         "puppeteer-core": {
-            "version": "22.9.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
-            "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
+            "version": "24.16.2",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.2.tgz",
+            "integrity": "sha512-areKSSQzpoHa5nCk3uD/o504yjrW5ws0N6jZfdFZ3a4H+Q7NBgvuDydjN5P87jN4Rj+eIpLcK3ELOThTtYuuxg==",
             "dev": true,
             "requires": {
-                "@puppeteer/browsers": "2.2.3",
-                "chromium-bidi": "0.5.19",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1286932",
-                "ws": "8.17.0"
+                "@puppeteer/browsers": "2.10.6",
+                "chromium-bidi": "7.3.1",
+                "debug": "^4.4.1",
+                "devtools-protocol": "0.0.1475386",
+                "typed-query-selector": "^2.12.0",
+                "ws": "^8.18.3"
             },
             "dependencies": {
+                "debug": {
+                    "version": "4.4.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+                    "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.3"
+                    }
+                },
                 "ws": {
-                    "version": "8.17.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-                    "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+                    "version": "8.18.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+                    "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
                     "dev": true,
                     "requires": {}
                 }
@@ -7590,12 +7464,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true
-        },
-        "queue-tick": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
             "dev": true
         },
         "randombytes": {
@@ -7772,9 +7640,9 @@
             "dev": true
         },
         "semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "dev": true
         },
         "serialize-javascript": {
@@ -7848,36 +7716,30 @@
             "dev": true
         },
         "socks": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "dev": true,
             "requires": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
             }
         },
         "socks-proxy-agent": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
-            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "dev": true,
             "requires": {
-                "agent-base": "^7.1.1",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             }
         },
         "source-map": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
             "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-            "dev": true
-        },
-        "sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
         },
         "statuses": {
@@ -7899,14 +7761,14 @@
             "dev": true
         },
         "streamx": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
             "dev": true,
             "requires": {
                 "bare-events": "^2.2.0",
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
             }
         },
         "string-width": {
@@ -7980,13 +7842,13 @@
             }
         },
         "tar-fs": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-            "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
             "dev": true,
             "requires": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0",
+                "bare-fs": "^4.0.1",
+                "bare-path": "^3.0.0",
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             }
@@ -8002,11 +7864,14 @@
                 "streamx": "^2.15.0"
             }
         },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true
+        "text-decoder": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "dev": true,
+            "requires": {
+                "b4a": "^1.6.4"
+            }
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -8033,9 +7898,9 @@
             }
         },
         "tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true
         },
         "tsscmp": {
@@ -8066,21 +7931,17 @@
                 "mime-types": "~2.1.24"
             }
         },
+        "typed-query-selector": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+            "dev": true
+        },
         "typical": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
             "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
             "dev": true
-        },
-        "unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "requires": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
         },
         "undici-types": {
             "version": "5.26.5",
@@ -8088,22 +7949,10 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
-        "universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true
-        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-            "dev": true
-        },
-        "urlpattern-polyfill": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "v8-to-istanbul": {
@@ -8181,12 +8030,6 @@
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
         },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
         "yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -8243,9 +8086,9 @@
             "dev": true
         },
         "zod": {
-            "version": "3.22.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "patch-version": "npm --no-git-tag-version version patch"
     },
     "devDependencies": {
-        "@web/test-runner": "^0.18.2",
-        "@web/test-runner-playwright": "^0.11.0",
+        "@web/test-runner": "^0.20.2",
+        "@web/test-runner-playwright": "^0.11.1",
         "cgi": "^0.3.1",
         "chai": "^4.3.7",
         "mocha": "^10.2.0"


### PR DESCRIPTION
## Summary
- update `@web/test-runner` and `@web/test-runner-playwright` to latest versions
- pin CI runners to `ubuntu-22.04` for stability

## Testing
- `npm test` *(fails: Cannot require() ES Module in a cycle)*
- `npm run test-browser` *(fails: Browser tests did not finish within timeout; 404 for test-browser/lg2.js)*
- `npm run test-browser-async` *(fails: Failed to fetch dynamically imported module: lg2_async.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a03a5b620c8326bd22233090eb9bcd