### PR TITLE
small setup script fix for posix systems for sed commands

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,5 +10,5 @@ cp -r libgit2patchedfiles/src/* libgit2/src/libgit2/
 echo 'set(CMAKE_C90_STANDARD_COMPILE_OPTION "-std=gnu90")' >> libgit2/examples/CMakeLists.txt
 echo 'set(CMAKE_C90_STANDARD_COMPILE_OPTION "-std=gnu90")' >> libgit2/src/libgit2/CMakeLists.txt
 echo 'set(CMAKE_C90_STANDARD_COMPILE_OPTION "-std=gnu90")' >> libgit2/src/util/CMakeLists.txt
-sed -i 's/GIT_PACK_FILE_MODE 0444/GIT_PACK_FILE_MODE 0644/g' libgit2/src/libgit2/pack.h
-sed -i 's/GIT_OBJECT_FILE_MODE 0444/GIT_OBJECT_FILE_MODE 0644/g' libgit2/src/libgit2/odb.h
+sed -i .orig 's/GIT_PACK_FILE_MODE 0444/GIT_PACK_FILE_MODE 0644/g' libgit2/src/libgit2/pack.h
+sed -i .orig 's/GIT_OBJECT_FILE_MODE 0444/GIT_OBJECT_FILE_MODE 0644/g' libgit2/src/libgit2/odb.h


### PR DESCRIPTION
This is a simple fix for posix systems like macOS. The setup script lands on an error for sed commands when using the `-i` flag. I'm able to successfully run those sed commands when I add the fix myself.

### To test:

**Please ensure that this is tested on other systems! (Linux, Windows, as necessary)**

1. Perform the setup as described in the README
2. Note that when you perform the step that instructs you to run the setup script, `./setup.sh`, an error occurs on the last two steps, those which perform a sed text replace.
3. Note that with this change, you should see the last two steps succeed.
4. You can confirm that the last two steps worked if it successfully changes the files `libgit2/src/libgit2/pack.h` and `libgit2/src/libgit2/odb.h` with the replacement strings, `GIT_PACK_FILE_MODE 0444 -> GIT_PACK_FILE_MODE 0644` and `GIT_OBJECT_FILE_MODE 0444 -> GIT_OBJECT_FILE_MODE 0644` respectively. 

resolves #106 