### PR TITLE
Fix devcontainer for ARM Macs, prepare v0.0.14 release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,13 @@
 {
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers/features/python:1": {}
+    },
+    "workspaceMount": "source=wasm-git-volume,target=/workspaces/wasm-git,type=volume",
+    "workspaceFolder": "/workspaces/wasm-git",
+    "initializeCommand": "docker volume create wasm-git-volume 2>/dev/null || true",
+    "onCreateCommand": "sudo chown vscode:vscode /workspaces/wasm-git && if [ ! -d .git ]; then git clone https://github.com/petersalomonsen/wasm-git.git /tmp/wasm-git-clone && cp -a /tmp/wasm-git-clone/. . && rm -rf /tmp/wasm-git-clone; fi",
     "postCreateCommand": "/workspaces/wasm-git/.devcontainer/post-create.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,6 @@
         "ghcr.io/devcontainers/features/node:1": {},
         "ghcr.io/devcontainers/features/python:1": {}
     },
-    "workspaceMount": "source=wasm-git-volume,target=/workspaces/wasm-git,type=volume",
-    "workspaceFolder": "/workspaces/wasm-git",
-    "initializeCommand": "docker volume create wasm-git-volume 2>/dev/null || true",
-    "onCreateCommand": "sudo chown vscode:vscode /workspaces/wasm-git && if [ ! -d .git ]; then git clone https://github.com/petersalomonsen/wasm-git.git /tmp/wasm-git-clone && cp -a /tmp/wasm-git-clone/. . && rm -rf /tmp/wasm-git-clone; fi",
     "postCreateCommand": "/workspaces/wasm-git/.devcontainer/post-create.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+sudo apt-get update && sudo apt-get install -y cmake
 curl https://wasmtime.dev/install.sh -sSf | bash
 npm install
 sh setup.sh

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,5 +10,7 @@ git pull
 ./emsdk activate 4.0.23
 cd ..
 
+echo 'source "/workspaces/wasm-git/emsdk/emsdk_env.sh" 2>/dev/null' >> ~/.bashrc
+
 npx playwright install-deps
 npx playwright install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
           cd emscriptenbuild
           ./build.sh Release
           ./build.sh Release-async
+          ./build.sh Release-opfs
           cd ..
           set -e
           npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ emsdk
 nodefsclonetest
 google-chrome-stable_current_amd64.deb
 test-results
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasm-git",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wasm-git",
-            "version": "0.0.13",
+            "version": "0.0.14",
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
                 "@web/test-runner": "^0.20.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,8 +1943,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
             "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "5.0.0",
@@ -3978,7 +3977,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
             "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
             },
@@ -6147,8 +6145,7 @@
             "version": "0.0.1475386",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
             "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "diff": {
             "version": "5.0.0",
@@ -7626,7 +7623,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
             "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@rollup/rollup-android-arm-eabi": "4.17.2",
                 "@rollup/rollup-android-arm64": "4.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasm-git",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "type": "module",
     "author": {
         "name": "Peter Salomonsen",

--- a/preparepublishnpm.sh
+++ b/preparepublishnpm.sh
@@ -5,5 +5,7 @@ cp emscriptenbuild/libgit2/examples/lg2.wasm .
 cp emscriptenbuild/libgit2/examples/lg2.js .
 cp emscriptenbuild/libgit2/examples/lg2_async.wasm .
 cp emscriptenbuild/libgit2/examples/lg2_async.js .
+cp emscriptenbuild/libgit2/examples/lg2_opfs.wasm .
+cp emscriptenbuild/libgit2/examples/lg2_opfs.js .
 echo "publish --dry-run (run npm publish to finalize)"
 npm publish --dry-run


### PR DESCRIPTION
## Summary

### Devcontainer fixes
- Switch from `universal:2` image (no ARM/Apple Silicon support) to `base:ubuntu` with explicit `node` and `python` features
- Simplify devcontainer setup: rely on VS Code "Clone Repository in Container Volume" instead of custom Docker volume configuration
- Install `cmake` in post-create script (required by Emscripten `emcmake`)
- Source `emsdk_env.sh` in `.bashrc` so Emscripten tools are available in new terminal sessions

### Release preparation (v0.0.14)
- Bump version to `0.0.14`
- Add OPFS build artifacts (`lg2_opfs.js`, `lg2_opfs.wasm`) to `preparepublishnpm.sh`

## Test plan
- [x] Build OPFS target with `./build.sh Release-opfs` in devcontainer
- [ ] Run full test suite (`npm run test`, `npm run test-browser`, etc.)
- [ ] Verify devcontainer works on ARM Mac via "Clone Repository in Container Volume"