### PR TITLE
Remove NODE_AUTH_TOKEN, use OIDC for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [ master ]
 permissions:
+  contents: read
   id-token: write
 jobs:
   default:
@@ -53,7 +54,5 @@ jobs:
             echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
             npm publish --dry-run
           else
-            npm publish --provenance
+            npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` env var — no longer needed with trusted publishing
- OIDC token (via `id-token: write`) handles npm authentication directly
- Previous granular token was still triggering OTP despite `--provenance`

## Test plan
- [ ] Verify publish succeeds without OTP error after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)