### PR TITLE
Test: npm trusted publishing without token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,11 @@ jobs:
           cp package/lg2_async.* test-browser-async/
           npm run test-browser-async
           BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          if [[ "$VERSION" = "$NEWVERSION" || "$BRANCH" != "master" ]]; then
+          if [[ "$VERSION" != "$NEWVERSION" && "$BRANCH" = "master" ]]; then
+            npm publish --provenance --access public
+          elif [[ "$VERSION" != "$NEWVERSION" ]]; then
             echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
             npm publish --dry-run
           else
-            npm publish --provenance --access public
+            echo "version $VERSION is already published, skipping publish"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,12 +49,10 @@ jobs:
           rm test-browser-async/lg2_async.*
           cp package/lg2_async.* test-browser-async/
           npm run test-browser-async
-          npm publish --dry-run
-          npm publish --provenance --access public
-          # BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          # if [[ "$VERSION" = "$NEWVERSION" || "$BRANCH" != "master" ]]; then
-          #   echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
-          #   npm publish --dry-run
-          # else
-          #   npm publish --provenance --access public
-          # fi
+          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          if [[ "$VERSION" = "$NEWVERSION" || "$BRANCH" != "master" ]]; then
+            echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
+            npm publish --dry-run
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
     name: "Default"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Default
         run: |
@@ -49,10 +49,12 @@ jobs:
           rm test-browser-async/lg2_async.*
           cp package/lg2_async.* test-browser-async/
           npm run test-browser-async
-          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          if [[ "$VERSION" = "$NEWVERSION" || "$BRANCH" != "master" ]]; then
-            echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
-            npm publish --dry-run
-          else
-            npm publish --provenance --access public
-          fi
+          npm publish --dry-run
+          npm publish --provenance --access public
+          # BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+          # if [[ "$VERSION" = "$NEWVERSION" || "$BRANCH" != "master" ]]; then
+          #   echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
+          #   npm publish --dry-run
+          # else
+          #   npm publish --provenance --access public
+          # fi

--- a/preparepublishnpm.sh
+++ b/preparepublishnpm.sh
@@ -7,5 +7,4 @@ cp emscriptenbuild/libgit2/examples/lg2_async.wasm .
 cp emscriptenbuild/libgit2/examples/lg2_async.js .
 cp emscriptenbuild/libgit2/examples/lg2_opfs.wasm .
 cp emscriptenbuild/libgit2/examples/lg2_opfs.js .
-echo "publish --dry-run (run npm publish to finalize)"
-npm publish --dry-run
+echo "npm package prepared"


### PR DESCRIPTION
## Summary
- Use npm trusted publishing (OIDC) — no `NODE_AUTH_TOKEN` needed
- Upgrade to `actions/checkout@v4`, `actions/setup-node@v4`, Node 24
- Publish with `--provenance --access public`

## Test plan
- [x] Verified `npm publish --provenance --access public` succeeded from PR run
- [x] `wasm-git@0.0.14` published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)