### PR TITLE
SAB-free OPFS builds (ASYNCIFY + JSPI) with auto-detecting loader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,15 @@ jobs:
         run: |
           npm install
           npx playwright install-deps
-          npx playwright install
+          # The loader matrix needs chromium, firefox and webkit. The playwright
+          # CDN download occasionally stalls right after reaching 100%; wrap it
+          # in a timeout+retry so a stalled attempt is killed and retried rather
+          # than hanging the job.
+          for i in 1 2 3 4 5; do
+            timeout 300 npx playwright install && break
+            echo "playwright install attempt $i stalled or failed; retrying..."
+            sleep 5
+          done
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,12 +96,13 @@ jobs:
           npm install
           npx playwright install-deps
           # The loader matrix needs chromium, firefox and webkit. The playwright
-          # CDN download occasionally stalls right after reaching 100%; wrap it
-          # in a timeout+retry so a stalled attempt is killed and retried rather
-          # than hanging the job.
-          for i in 1 2 3 4 5; do
-            timeout 300 npx playwright install && break
+          # install intermittently hangs right after a download reaches 100%, so
+          # wrap it in a bounded timeout+retry that force-kills (-k) a stalled
+          # attempt and clears any lingering downloader before retrying.
+          for i in 1 2 3; do
+            timeout -k 15 180 npx playwright install && break
             echo "playwright install attempt $i stalled or failed; retrying..."
+            pkill -f playwright || true
             sleep 5
           done
           sh setup.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,40 @@ jobs:
           set -e
           npm run test-browser-opfs
           npm run test-opfs-example
+  opfs-sab-free:
+    name: OPFS (SAB-free ASYNCIFY + JSPI + loader)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build SAB-free OPFS variants and test
+        run: |
+          npm install
+          npx playwright install-deps
+          npx playwright install
+          sh setup.sh
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install 4.0.23
+          ./emsdk activate 4.0.23
+          cd ..
+          source ./emsdk/emsdk_env.sh
+          # Build all three OPFS variants, copying each output to the repo root.
+          # Clean the build tree between variants so changed link flags fully reconfigure.
+          cd emscriptenbuild
+          clean() { rm -rf CMakeCache.txt CMakeFiles libgit2 Makefile cmake_install.cmake; }
+          ./build.sh Release-opfs       && cp libgit2/examples/lg2_opfs.js       libgit2/examples/lg2_opfs.wasm       ../ && clean
+          ./build.sh Release-opfs-async && cp libgit2/examples/lg2_opfs_async.js libgit2/examples/lg2_opfs_async.wasm ../ && clean
+          ./build.sh Release-opfs-jspi  && cp libgit2/examples/lg2_opfs_jspi.js  libgit2/examples/lg2_opfs_jspi.wasm  ../
+          cd ..
+          # Symlink the loader and all variant files into the non-isolated test dir
+          ln -s ../lg2_opfs_auto.js   test-browser-opfs-noniso/lg2_opfs_auto.js
+          ln -s ../lg2_opfs.js        test-browser-opfs-noniso/lg2_opfs.js
+          ln -s ../lg2_opfs.wasm      test-browser-opfs-noniso/lg2_opfs.wasm
+          ln -s ../lg2_opfs_async.js  test-browser-opfs-noniso/lg2_opfs_async.js
+          ln -s ../lg2_opfs_async.wasm test-browser-opfs-noniso/lg2_opfs_async.wasm
+          ln -s ../lg2_opfs_jspi.js   test-browser-opfs-noniso/lg2_opfs_jspi.js
+          ln -s ../lg2_opfs_jspi.wasm test-browser-opfs-noniso/lg2_opfs_jspi.wasm
+          set -e
+          npm run test-opfs-detect
+          npm run test-browser-opfs-noniso
+          npm run test-opfs-loader

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,15 @@ jobs:
           npm install
           npx playwright install-deps chromium
           # The publish job's browser tests (test-browser, test-browser-async)
-          # only use chromium, so install just chromium. The playwright CDN
-          # download occasionally stalls right after reaching 100%, hanging the
-          # whole job, so wrap it in a timeout+retry: a stalled attempt is killed
-          # and retried instead of blocking forever.
-          for i in 1 2 3 4 5; do
-            timeout 240 npx playwright install chromium && break
+          # only use chromium, so install just chromium. The playwright install
+          # intermittently hangs right after the download reaches 100%, so wrap
+          # it in a bounded timeout+retry that force-kills (-k) a stalled attempt
+          # and clears any lingering downloader before retrying — it can never
+          # hang the job for more than a few minutes.
+          for i in 1 2 3; do
+            timeout -k 15 120 npx playwright install chromium && break
             echo "playwright install attempt $i stalled or failed; retrying..."
+            pkill -f playwright || true
             sleep 5
           done
           sh setup.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,15 @@ jobs:
           npm install
           npx playwright install-deps chromium
           # The publish job's browser tests (test-browser, test-browser-async)
-          # only use chromium; installing just chromium avoids occasional hangs
-          # downloading firefox/webkit from the playwright CDN.
-          npx playwright install chromium
+          # only use chromium, so install just chromium. The playwright CDN
+          # download occasionally stalls right after reaching 100%, hanging the
+          # whole job, so wrap it in a timeout+retry: a stalled attempt is killed
+          # and retried instead of blocking forever.
+          for i in 1 2 3 4 5; do
+            timeout 240 npx playwright install chromium && break
+            echo "playwright install attempt $i stalled or failed; retrying..."
+            sleep 5
+          done
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,21 @@
 name: Publish
-# Runs only on pushes to master (actual releases). Pull requests are fully
-# validated by the CI workflow (.github/workflows/main.yml), which builds every
-# variant and runs all tests, so the heavy ~25-min publish dry-run is not needed
-# on PRs.
+# Runs on:
+#   - push to master      → real release (npm publish when the version changed)
+#   - merge_group         → pre-merge dry-run gate (when a PR is queued to merge)
+# It deliberately does NOT run on `pull_request`, so it doesn't rebuild on every
+# push to a PR; instead, with the merge queue enabled and this job marked as a
+# required check, the dry-run runs exactly once right before the PR merges.
+# Day-to-day PR validation is handled by the CI workflow (main.yml).
 on:
   push:
     branches: [ master ]
+  merge_group:
 permissions:
   contents: read
   id-token: write
 jobs:
   default:
-    name: "Default"
+    name: "Publish (build + dry-run)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,11 +68,12 @@ jobs:
           rm test-browser-async/lg2_async.*
           cp package/lg2_async.* test-browser-async/
           npm run test-browser-async
-          BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          if [[ "$VERSION" != "$NEWVERSION" && "$BRANCH" = "master" ]]; then
+          # Only a real push to master publishes; merge_group (pre-merge gate)
+          # always does a dry-run, never a real publish.
+          if [[ "$VERSION" != "$NEWVERSION" && "$GITHUB_EVENT_NAME" = "push" ]]; then
             npm publish --provenance --access public
           elif [[ "$VERSION" != "$NEWVERSION" ]]; then
-            echo "version change is $VERSION->$NEWVERSION, branch is $BRANCH, not publishing, only dry-run"
+            echo "version change is $VERSION->$NEWVERSION, event is $GITHUB_EVENT_NAME, not publishing, only dry-run"
             npm publish --dry-run
           else
             echo "version $VERSION is already published, skipping publish"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Default
         run: |
           npm install
-          npx playwright install-deps
-          npx playwright install
+          npx playwright install-deps chromium
+          # The publish job's browser tests (test-browser, test-browser-async)
+          # only use chromium; installing just chromium avoids occasional hangs
+          # downloading firefox/webkit from the playwright CDN.
+          npx playwright install chromium
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish
+# Runs only on pushes to master (actual releases). Pull requests are fully
+# validated by the CI workflow (.github/workflows/main.yml), which builds every
+# variant and runs all tests, so the heavy ~25-min publish dry-run is not needed
+# on PRs.
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
           ./build.sh Release
           ./build.sh Release-async
           ./build.sh Release-opfs
+          ./build.sh Release-opfs-async
+          ./build.sh Release-opfs-jspi
           cd ..
           set -e
           npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,17 @@ lg2_async.js
 lg2_async.wasm
 lg2_opfs.js
 lg2_opfs.wasm
+lg2_opfs_async.js
+lg2_opfs_async.wasm
+lg2_opfs_jspi.js
+lg2_opfs_jspi.wasm
+test-browser-opfs-noniso/lg2_opfs_auto.js
+test-browser-opfs-noniso/lg2_opfs.js
+test-browser-opfs-noniso/lg2_opfs.wasm
+test-browser-opfs-noniso/lg2_opfs_async.js
+test-browser-opfs-noniso/lg2_opfs_async.wasm
+test-browser-opfs-noniso/lg2_opfs_jspi.js
+test-browser-opfs-noniso/lg2_opfs_jspi.wasm
 .DS_Store
 .vscode
 node_modules

--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ Wasm-git packages are built in three variants: Synchronous, Asynchronous, and OP
 
 The async version use [Emscripten Asyncify](https://emscripten.org/docs/porting/asyncify.html), which allows calling the Wasm-git functions with `async` / `await`. It can also run from the main thread in the browser. Asyncify increase the binary size because of instrumentation to unwind and rewind WebAssembly state, but makes it possible to have simple client code without exchanging data with worker threads like in the sync version.
 
-The OPFS version uses Emscripten's WASMFS with the OPFS (Origin Private File System) backend. Unlike the async version, it does not use Asyncify — instead it runs synchronously inside a Web Worker (using pthreads internally for the WASMFS OPFS backend). OPFS provides better performance and quota management compared to IDBFS, making it ideal for modern browser-based applications that need persistent storage.
+The OPFS version stores data in the browser's [Origin Private File System](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) (OPFS), which provides better performance and quota management than IDBFS. OPFS's directory/metadata operations are **async-only**, so reaching them from synchronous libgit2 code needs an async bridge. wasm-git ships **three** OPFS variants that bridge it differently — see [OPFS variants](#opfs-variants-and-the-runtime-loader) below.
 
 Examples of using Wasm-git can be found in the tests:
 
 - [test](./test/) for NodeJS
 - [test-browser](./test-browser/) for the sync version in the browser with a web worker
 - [test-browser-async](./test-browser-async/) for the async version in the browser
-- [test-browser-opfs](./test-browser-opfs/) for the OPFS version in the browser
+- [test-browser-opfs](./test-browser-opfs/) for the OPFS (pthreads/WASMFS) version in the browser
+- [test-browser-opfs-noniso](./test-browser-opfs-noniso/) for the SAB-free OPFS variants (ASYNCIFY + JSPI) and the runtime loader
 
 The examples shows importing the `lg2.js` / `lg2_async.js` / `lg2_opfs.js` modules from the local build, but you may also access these from releases available at public CDNs.
 
@@ -94,6 +95,69 @@ postMessage({ done: true });
 
 See [test-browser-opfs/worker.js](./test-browser-opfs/worker.js) for a complete working example.
 
+## OPFS variants and the runtime loader
+
+OPFS's open/dir/metadata operations (`getFileHandle`, `getDirectoryHandle`,
+`removeEntry`, `entries`, `createSyncAccessHandle`) are **async-only**. To call
+them from libgit2's synchronous file IO, wasm-git ships three OPFS builds that
+bridge async→sync in different ways:
+
+| Build | File | Bridge | SharedArrayBuffer / cross-origin isolation | wasm size | Relative speed |
+|-------|------|--------|--------------------------------------------|-----------|----------------|
+| **pthreads / WASMFS** | `lg2_opfs.js` | WASMFS OPFS backend blocks a worker thread via `Atomics.wait` | **Required** (COOP/COEP) | ~920 KB | fastest |
+| **JSPI** | `lg2_opfs_jspi.js` | [JSPI](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Suspending) — native WebAssembly stack switching | Not required | ~805 KB | fast |
+| **ASYNCIFY** | `lg2_opfs_async.js` | [Asyncify](https://emscripten.org/docs/porting/asyncify.html) — wasm rewritten to unwind/rewind its stack | Not required | ~1.5 MB | slower (instrumentation overhead) |
+
+(wasm sizes are for `-O3` release builds and will drift; JSPI is the smallest
+because it needs no stack-rewriting instrumentation, ASYNCIFY the largest for the
+same reason.)
+
+The pthreads build needs `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy`
+headers (cross-origin isolation), which some hosts (e.g. NEAR web4) cannot set.
+The **JSPI** and **ASYNCIFY** builds are *SAB-free*: they persist to OPFS by
+suspending the wasm stack across the async OPFS calls, so they run with
+`self.crossOriginIsolated === false`. All three must run inside a **Web Worker**
+(OPFS sync access handles require one).
+
+### Runtime loader (`lg2_opfs_auto.js`)
+
+`lg2_opfs_auto.js` picks the most optimal supported build at runtime and exposes
+a uniform git API over all three. Selection order:
+
+1. **pthreads** when the page is cross-origin isolated
+   (`crossOriginIsolated === true` and `SharedArrayBuffer` exists);
+2. **JSPI** when available (`WebAssembly.Suspending` / `WebAssembly.promising`);
+3. **ASYNCIFY** otherwise (universal fallback).
+
+If OPFS itself is unavailable (`navigator.storage.getDirectory` missing, insecure
+context), `selectOpfsVariant()` returns `null` — fall back to the non-OPFS IDBFS
+build (`lg2.js`).
+
+```javascript
+// inside a Web Worker (type: 'module')
+import { loadOpfsGit, selectOpfsVariant } from './lg2_opfs_auto.js';
+
+console.log(selectOpfsVariant());      // 'pthreads' | 'jspi' | 'asyncify' | null
+
+const git = await loadOpfsGit({ user: 'Your Name', email: 'you@example.com' });
+console.log(git.variant);              // which build was loaded
+
+await git.clone('https://example.com/repo.git', 'repo.git');
+await git.writeFile('repo.git', 'a.txt', 'hello');
+await git.addCommitPush('repo.git', 'a.txt', 'add a.txt');
+console.log(git.readFile('repo.git', 'a.txt'));   // 'hello'
+
+// After a reload, restore an existing repo from OPFS before using it:
+await git.syncRepo('repo.git');
+```
+
+The detection helpers (`detectOpfsEnvironment`, `selectOpfsVariant`) are pure
+functions that accept an `env` object, so they can be unit-tested or forced
+(see [test/opfs-detect.spec.js](./test/opfs-detect.spec.js)).
+
+See [test-browser-opfs-noniso/worker.js](./test-browser-opfs-noniso/worker.js)
+for a complete worker built on the loader.
+
 # Building and developing
 
 ## Prerequisites
@@ -140,10 +204,12 @@ See [test-browser-opfs/worker.js](./test-browser-opfs/worker.js) for a complete 
    ./build.sh Release-async # Release async build
    ```
 
-   For OPFS versions (with WASMFS and OPFS support):
+   For OPFS versions:
    ```bash
-   ./build.sh Debug-opfs   # Debug OPFS build
-   ./build.sh Release-opfs # Release OPFS build
+   ./build.sh Release-opfs       # pthreads / WASMFS OPFS build (needs COOP/COEP)
+   ./build.sh Release-opfs-jspi  # SAB-free OPFS build using JSPI
+   ./build.sh Release-opfs-async # SAB-free OPFS build using ASYNCIFY
+   # (Debug-opfs, Debug-opfs-jspi and Debug-opfs-async also exist)
    ```
 
 5. **Install npm dependencies**
@@ -153,10 +219,13 @@ See [test-browser-opfs/worker.js](./test-browser-opfs/worker.js) for a complete 
 
 6. **Run tests**
    ```bash
-   npm test                  # Run Node.js tests
-   npm run test-browser      # Run browser tests (sync version)
-   npm run test-browser-async # Run browser tests (async version)
-   npm run test-browser-opfs # Run browser tests (OPFS version)
+   npm test                         # Run Node.js tests
+   npm run test-browser             # Run browser tests (sync version)
+   npm run test-browser-async       # Run browser tests (async version)
+   npm run test-browser-opfs        # OPFS pthreads/WASMFS tests (cross-origin isolated)
+   npm run test-browser-opfs-noniso # SAB-free OPFS tests (ASYNCIFY + JSPI, non-isolated)
+   npm run test-opfs-detect         # Loader variant-detection unit tests
+   npm run test-opfs-loader         # Multi-browser loader selection tests (Chromium/Firefox/WebKit)
    ```
 
 ## Development Options
@@ -174,7 +243,13 @@ The [Github actions test pipeline](./.github/workflows/main.yml) shows all the c
 After building, you'll find the following files in `emscriptenbuild/libgit2/examples/`:
 - `lg2.js` and `lg2.wasm` - Synchronous version
 - `lg2_async.js` and `lg2_async.wasm` - Asynchronous version with Asyncify
-- `lg2_opfs.js` and `lg2_opfs.wasm` - OPFS version with WASMFS
+- `lg2_opfs.js` and `lg2_opfs.wasm` - OPFS version with WASMFS + pthreads
+- `lg2_opfs_jspi.js` and `lg2_opfs_jspi.wasm` - SAB-free OPFS version using JSPI
+- `lg2_opfs_async.js` and `lg2_opfs_async.wasm` - SAB-free OPFS version using ASYNCIFY
+
+The runtime loader `lg2_opfs_auto.js` (a hand-written module, not a build output)
+selects the best of the three OPFS builds at runtime — see
+[OPFS variants and the runtime loader](#opfs-variants-and-the-runtime-loader).
 
 These files are also available from npm packages and CDNs for production use.
 
@@ -197,13 +272,16 @@ Wasm-git supports multiple filesystem backends for different use cases:
 - **Build target**: Default (`./build.sh Release`)
 - **Platform**: Node.js only
 
-### OPFS (Origin Private File System via WASMFS)
+### OPFS (Origin Private File System)
 - **Use case**: Modern browser persistent storage with better performance and quota management
-- **Build target**: OPFS builds (`./build.sh Release-opfs` or `./build.sh Debug-opfs`)
-- **Browser support**: Chrome 86+, Edge 86+, Firefox 111+, Safari 15.2+
+- **Browser support**: Chrome 86+, Edge 86+, Firefox 111+, Safari 15.2+ (JSPI variant: Chromium-based browsers with JSPI)
 - **Advantages**: Better performance and quota compared to IDBFS
-- **Requirements**: Must run in a Web Worker; server must send `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` (or `credentialless`) headers to enable SharedArrayBuffer
-- **Note**: Uses Emscripten's WASMFS with OPFS backend and `-pthread` (no Asyncify); `callMain` is synchronous
+- **Requirements**: Must run in a Web Worker (OPFS sync access handles require one)
+- **Three variants** — see [OPFS variants and the runtime loader](#opfs-variants-and-the-runtime-loader):
+  - **pthreads / WASMFS** (`./build.sh Release-opfs` → `lg2_opfs.js`): synchronous `callMain`; requires cross-origin isolation (`Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp`/`credentialless`) for SharedArrayBuffer.
+  - **JSPI** (`./build.sh Release-opfs-jspi` → `lg2_opfs_jspi.js`): SAB-free; async `callMain`; smallest binary.
+  - **ASYNCIFY** (`./build.sh Release-opfs-async` → `lg2_opfs_async.js`): SAB-free; async `callMain`; universal fallback, largest binary.
+  - `lg2_opfs_auto.js` selects the best supported variant at runtime.
 
 ## Troubleshooting
 

--- a/emscriptenbuild/build.sh
+++ b/emscriptenbuild/build.sh
@@ -6,6 +6,8 @@ POST_JS="--post-js $(pwd)/post.js"
 FS_LIBRARIES="-lidbfs.js -lnodefs.js"
 FS_EXPORTS="'FS','MEMFS','IDBFS','NODEFS','callMain','HEAPU8'"
 EXTRA_CMAKE_DEFINES=""
+# Link-only flags (e.g. --js-library, which clang rejects during compilation).
+EXTRA_LINK_FLAGS=""
 
 # Reset in case we've done an '-async' build
 cp ../libgit2patchedfiles/src/transports/emscriptenhttp.c ../libgit2/src/libgit2/transports/emscriptenhttp.c
@@ -58,14 +60,56 @@ elif [ "$1" == "Debug-opfs" ]; then
     EXTRA_CMAKE_DEFINES="-DUSE_THREADS=OFF -DUSE_NSEC=OFF"
     # Copy OPFS exports helper to examples for WASMFS builds
     cp ../libgit2patchedfiles/examples/opfs_exports.c ../libgit2/examples/opfs_exports.c
+# SAB-free OPFS builds: persist to OPFS by suspending the wasm stack across the
+# async OPFS calls (no pthreads, no SharedArrayBuffer). The persistence layer
+# lives in the --js-library library_opfs.js. HTTP uses the sync transport (runs
+# in a Web Worker); only the OPFS filesystem calls are suspended.
+elif [ "$1" == "Release-opfs-async" ]; then
+    BUILD_TYPE=Release
+    EXTRA_CMAKE_C_FLAGS="-O3 -sASYNCIFY -sASYNCIFY_STACK_SIZE=1048576"
+    POST_JS="--post-js $(pwd)/post.js --post-js $(pwd)/post-opfs.js"
+    EXTRA_LINK_FLAGS="--js-library $(pwd)/library_opfs.js"
+    export LG2_OUTPUT_NAME=lg2_opfs_async
+    FS_LIBRARIES=""
+    FS_EXPORTS="'FS','callMain','HEAPU8','ccall'"
+    EXTRA_CMAKE_DEFINES="-DUSE_THREADS=OFF -DUSE_NSEC=OFF"
+elif [ "$1" == "Debug-opfs-async" ]; then
+    BUILD_TYPE=Debug
+    EXTRA_CMAKE_C_FLAGS="-sASYNCIFY -sASYNCIFY_STACK_SIZE=1048576"
+    POST_JS="--post-js $(pwd)/post.js --post-js $(pwd)/post-opfs.js"
+    EXTRA_LINK_FLAGS="--js-library $(pwd)/library_opfs.js"
+    export LG2_OUTPUT_NAME=lg2_opfs_async
+    FS_LIBRARIES=""
+    FS_EXPORTS="'FS','callMain','HEAPU8','ccall'"
+    EXTRA_CMAKE_DEFINES="-DUSE_THREADS=OFF -DUSE_NSEC=OFF"
+elif [ "$1" == "Release-opfs-jspi" ]; then
+    BUILD_TYPE=Release
+    EXTRA_CMAKE_C_FLAGS="-O3 -sJSPI"
+    POST_JS="--post-js $(pwd)/post.js --post-js $(pwd)/post-opfs.js"
+    EXTRA_LINK_FLAGS="--js-library $(pwd)/library_opfs.js"
+    export LG2_OUTPUT_NAME=lg2_opfs_jspi
+    FS_LIBRARIES=""
+    FS_EXPORTS="'FS','callMain','HEAPU8','ccall'"
+    EXTRA_CMAKE_DEFINES="-DUSE_THREADS=OFF -DUSE_NSEC=OFF"
+elif [ "$1" == "Debug-opfs-jspi" ]; then
+    BUILD_TYPE=Debug
+    EXTRA_CMAKE_C_FLAGS="-sJSPI"
+    POST_JS="--post-js $(pwd)/post.js --post-js $(pwd)/post-opfs.js"
+    EXTRA_LINK_FLAGS="--js-library $(pwd)/library_opfs.js"
+    export LG2_OUTPUT_NAME=lg2_opfs_jspi
+    FS_LIBRARIES=""
+    FS_EXPORTS="'FS','callMain','HEAPU8','ccall'"
+    EXTRA_CMAKE_DEFINES="-DUSE_THREADS=OFF -DUSE_NSEC=OFF"
 fi
 
 # Before building, remove any ../libgit2/src/ transports/emscriptenhttp.c left from running setup.sh
 [ -f "../libgit2/src/libgit2/transports/emscriptenhttp-async.c" ] && rm ../libgit2/src/libgit2/transports/emscriptenhttp-async.c
-# Remove OPFS exports for non-OPFS builds to avoid link errors
-if [[ "$1" != *"opfs"* ]]; then
+# The WASMFS OPFS exports (opfs_exports.c) only link against the WASMFS/pthreads
+# build. Keep it ONLY for the Release-opfs / Debug-opfs variants; remove it for
+# every other build (including the SAB-free OPFS variants) to avoid link errors.
+if [ "$1" != "Release-opfs" ] && [ "$1" != "Debug-opfs" ]; then
     [ -f "../libgit2/examples/opfs_exports.c" ] && rm ../libgit2/examples/opfs_exports.c
 fi
 
-emcmake cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="$EXTRA_CMAKE_C_FLAGS --pre-js $(pwd)/pre.js $POST_JS -s \"EXPORTED_RUNTIME_METHODS=[$FS_EXPORTS]\" -sFORCE_FILESYSTEM -sEXPORT_ES6 -s INVOKE_RUN=0 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=131072 $FS_LIBRARIES" -DREGEX_BACKEND=regcomp -DSONAME=OFF -DUSE_HTTPS=OFF -DBUILD_SHARED_LIBS=OFF -DTHREADSAFE=OFF -DUSE_SSH=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=ON $EXTRA_CMAKE_DEFINES ..
+emcmake cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_FLAGS="$EXTRA_CMAKE_C_FLAGS --pre-js $(pwd)/pre.js $POST_JS -s \"EXPORTED_RUNTIME_METHODS=[$FS_EXPORTS]\" -sFORCE_FILESYSTEM -sEXPORT_ES6 -s INVOKE_RUN=0 -s ALLOW_MEMORY_GROWTH=1 -s STACK_SIZE=131072 $FS_LIBRARIES" -DCMAKE_EXE_LINKER_FLAGS="$EXTRA_LINK_FLAGS" -DREGEX_BACKEND=regcomp -DSONAME=OFF -DUSE_HTTPS=OFF -DBUILD_SHARED_LIBS=OFF -DTHREADSAFE=OFF -DUSE_SSH=OFF -DBUILD_CLAR=OFF -DBUILD_EXAMPLES=ON $EXTRA_CMAKE_DEFINES ..
 emmake make lg2

--- a/emscriptenbuild/library_opfs.js
+++ b/emscriptenbuild/library_opfs.js
@@ -1,0 +1,337 @@
+/**
+ * library_opfs.js — SAB-free OPFS persistence for wasm-git.
+ *
+ * This Emscripten `--js-library` makes a sub-tree of the in-memory (MEMFS)
+ * filesystem persist to the browser's Origin Private File System (OPFS),
+ * WITHOUT requiring SharedArrayBuffer / cross-origin isolation.
+ *
+ * The standard OPFS build (`lg2_opfs`, WasmFS + pthreads) blocks a worker on
+ * the async OPFS API via `Atomics.wait`, which forces SharedArrayBuffer and
+ * therefore COOP/COEP cross-origin isolation. Here we instead suspend the wasm
+ * stack across the async OPFS calls using either ASYNCIFY or JSPI (the build
+ * flag decides which; `Asyncify.handleAsync` works under both). No threads, no
+ * SharedArrayBuffer.
+ *
+ * Model
+ * -----
+ * - MEMFS is mounted at `OPFS_ROOT` (`/opfs`) and acts as a working cache.
+ * - libgit2's POSIX file IO goes through the libc syscalls. We override the
+ *   four *mutating* path syscalls plus `fd_close` so that changes under
+ *   `/opfs` are mirrored to OPFS:
+ *       __syscall_mkdirat   → create OPFS directory
+ *       __syscall_unlinkat  → remove OPFS entry (file or dir)
+ *       __syscall_renameat  → OPFS has no rename: copy + delete
+ *       fd_close            → flush a written file's bytes to OPFS
+ *   Reads, stats and directory listings are served from the MEMFS cache, so
+ *   they stay fully synchronous and fast.
+ * - Each override is a *thin* wrapper: `return Asyncify.handleAsync(async ...)`.
+ *   All side-effectful JS (the matching `FS.*` call) runs INSIDE the once-only
+ *   async callback, so the asyncify unwind/rewind never double-executes it.
+ * - On startup (or after a reload) the consumer loads an existing repo's tree
+ *   from OPFS into the MEMFS cache via `Module.opfsLoadTree(path)` (plain async
+ *   JS — no wasm involved), after which everything is present for libgit2.
+ *
+ * Exposed on the Module instance (all async, OPFS-aware):
+ *   opfsLoadTree(path)            populate MEMFS cache from OPFS, returns bool
+ *   opfsRemoveTree(path)          delete a sub-tree from both MEMFS and OPFS
+ *   opfsExists(path)              does the path exist in OPFS?
+ *   opfsReadFile(path, enc?)      read a file straight from OPFS
+ *   opfsWriteFile(path, data)     write to OPFS *and* the MEMFS cache
+ *   opfsRoot                      the MEMFS mount point ('/opfs')
+ */
+
+addToLibrary({
+  $OPFS__deps: ['$FS', '$stringToUTF8', '$lengthBytesUTF8'],
+  $OPFS__postset: 'addOnPreRun(() => OPFS.init());',
+  $OPFS: {
+    root: '/opfs', // MEMFS mount point that mirrors the OPFS root directory
+
+    // ---- path helpers -----------------------------------------------------
+    isOpfsPath(p) {
+      return p === OPFS.root || p.startsWith(OPFS.root + '/');
+    },
+    // '/opfs/a/b' -> ['a','b']   (relative to the OPFS root directory)
+    toParts(p) {
+      var rel = p.slice(OPFS.root.length);
+      return rel.split('/').filter((s) => s.length > 0);
+    },
+
+    // ---- low level OPFS handle resolution (async) --------------------------
+    async dirHandle(parts, create) {
+      var dir = await navigator.storage.getDirectory();
+      for (var i = 0; i < parts.length; i++) {
+        dir = await dir.getDirectoryHandle(parts[i], { create: !!create });
+      }
+      return dir;
+    },
+    async fileHandle(parts, create) {
+      var parent = await OPFS.dirHandle(parts.slice(0, -1), create);
+      return await parent.getFileHandle(parts[parts.length - 1], { create: !!create });
+    },
+
+    // ---- primitive OPFS operations (async) --------------------------------
+    async writeBytes(parts, bytes) {
+      var fh = await OPFS.fileHandle(parts, true);
+      var ah = await fh.createSyncAccessHandle();
+      try {
+        ah.truncate(0);
+        ah.write(bytes, { at: 0 });
+        ah.flush();
+      } finally {
+        ah.close();
+      }
+    },
+    async readBytes(parts) {
+      var fh = await OPFS.fileHandle(parts, false);
+      var file = await fh.getFile();
+      return new Uint8Array(await file.arrayBuffer());
+    },
+    async mkdir(parts) {
+      await OPFS.dirHandle(parts, true);
+    },
+    async remove(parts) {
+      if (parts.length === 0) return; // never remove the root itself
+      var parent = await OPFS.dirHandle(parts.slice(0, -1), false);
+      try {
+        await parent.removeEntry(parts[parts.length - 1], { recursive: true });
+      } catch (e) {
+        /* already gone */
+      }
+    },
+    async list(parts) {
+      var dir = await OPFS.dirHandle(parts, false);
+      var entries = [];
+      for await (var [name, handle] of dir.entries()) {
+        entries.push({ name, kind: handle.kind });
+      }
+      return entries;
+    },
+    async exists(parts) {
+      if (parts.length === 0) return true;
+      try {
+        var parent = await OPFS.dirHandle(parts.slice(0, -1), false);
+        var name = parts[parts.length - 1];
+        for await (var [n] of parent.entries()) {
+          if (n === name) return true;
+        }
+        return false;
+      } catch (e) {
+        return false;
+      }
+    },
+
+    // ---- MEMFS helpers ----------------------------------------------------
+    // Ensure all MEMFS directories along `path` exist (path is absolute).
+    ensureMemDir(path) {
+      var parts = path.split('/').filter((s) => s.length > 0);
+      var cur = '';
+      for (var i = 0; i < parts.length; i++) {
+        cur += '/' + parts[i];
+        try {
+          FS.mkdir(cur);
+        } catch (e) {
+          /* EEXIST */
+        }
+      }
+    },
+    // Current bytes of a MEMFS file (sync).
+    memBytes(path) {
+      return FS.readFile(path); // Uint8Array
+    },
+
+    // ---- recursive load: OPFS -> MEMFS cache (async) ----------------------
+    async loadTree(memPath) {
+      var parts = OPFS.toParts(memPath);
+      // verify the top directory exists in OPFS
+      try {
+        await OPFS.dirHandle(parts, false);
+      } catch (e) {
+        return false; // not present in OPFS
+      }
+      OPFS.ensureMemDir(memPath);
+      var stack = [memPath];
+      while (stack.length) {
+        var d = stack.pop();
+        var entries = await OPFS.list(OPFS.toParts(d));
+        for (var i = 0; i < entries.length; i++) {
+          var child = d + '/' + entries[i].name;
+          if (entries[i].kind === 'directory') {
+            try { FS.mkdir(child); } catch (e) { /* EEXIST */ }
+            stack.push(child);
+          } else {
+            var bytes = await OPFS.readBytes(OPFS.toParts(child));
+            try { FS.unlink(child); } catch (e) {}
+            FS.writeFile(child, bytes);
+          }
+        }
+      }
+      return true;
+    },
+
+    // ---- recursive write: MEMFS -> OPFS (async) ---------------------------
+    // Used by rename (OPFS lacks a native rename, so we copy then delete).
+    async writeTree(memPath) {
+      var parts = OPFS.toParts(memPath);
+      var mode = FS.stat(memPath).mode;
+      if (FS.isDir(mode)) {
+        await OPFS.mkdir(parts);
+        var names = FS.readdir(memPath).filter((n) => n !== '.' && n !== '..');
+        for (var i = 0; i < names.length; i++) {
+          await OPFS.writeTree(memPath + '/' + names[i]);
+        }
+      } else {
+        await OPFS.writeBytes(parts, OPFS.memBytes(memPath));
+      }
+    },
+
+    // ---- recursive remove: MEMFS + OPFS (async) ---------------------------
+    async removeTree(memPath) {
+      // MEMFS side
+      try {
+        var st = FS.stat(memPath);
+        if (FS.isDir(st.mode)) {
+          var names = FS.readdir(memPath).filter((n) => n !== '.' && n !== '..');
+          for (var i = 0; i < names.length; i++) {
+            await OPFS.removeTree(memPath + '/' + names[i]);
+          }
+          FS.rmdir(memPath);
+        } else {
+          FS.unlink(memPath);
+        }
+      } catch (e) {
+        /* not in MEMFS */
+      }
+      // OPFS side
+      await OPFS.remove(OPFS.toParts(memPath));
+    },
+
+    // ---- expose the public async API on the Module instance ---------------
+    init() {
+      OPFS.ensureMemDir(OPFS.root);
+
+      Module['opfsRoot'] = OPFS.root;
+
+      Module['opfsLoadTree'] = (path) => OPFS.loadTree(path);
+
+      Module['opfsRemoveTree'] = (path) => OPFS.removeTree(path);
+
+      Module['opfsExists'] = (path) =>
+        OPFS.isOpfsPath(path) ? OPFS.exists(OPFS.toParts(path)) : Promise.resolve(FS.analyzePath(path).exists);
+
+      Module['opfsReadFile'] = async (path, enc) => {
+        var bytes = await OPFS.readBytes(OPFS.toParts(path));
+        return enc === 'utf8' ? new TextDecoder().decode(bytes) : bytes;
+      };
+
+      Module['opfsWriteFile'] = async (path, data) => {
+        var bytes = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+        OPFS.ensureMemDir(path.slice(0, path.lastIndexOf('/')));
+        try { FS.unlink(path); } catch (e) {}
+        FS.writeFile(path, bytes);
+        await OPFS.writeBytes(OPFS.toParts(path), bytes);
+      };
+    },
+  },
+
+  // =========================================================================
+  // Syscall overrides. Each is a thin wrapper so that the asyncify/JSPI
+  // suspend happens at the import boundary with no non-idempotent JS above it.
+  // The built-in syscall wrapper (SYSCALLS.varargs setup + errno try/catch) is
+  // NOT applied to user-library overrides, so we replicate it by hand.
+  // =========================================================================
+
+  __syscall_mkdirat__deps: ['$OPFS', '$FS', '$SYSCALLS'],
+  __syscall_mkdirat__async: true,
+  __syscall_mkdirat: function (dirfd, path, mode) {
+    var p = SYSCALLS.calculateAt(dirfd, SYSCALLS.getStr(path));
+    if (!OPFS.isOpfsPath(p)) {
+      try { FS.mkdir(p, mode, 0); return 0; }
+      catch (e) { if (e.name !== 'ErrnoError') throw e; return -e.errno; }
+    }
+    return Asyncify.handleAsync(async () => {
+      try {
+        FS.mkdir(p, mode, 0);
+        await OPFS.mkdir(OPFS.toParts(p));
+        return 0;
+      } catch (e) {
+        if (e.name !== 'ErrnoError') throw e;
+        return -e.errno;
+      }
+    });
+  },
+
+  __syscall_unlinkat__deps: ['$OPFS', '$FS', '$SYSCALLS'],
+  __syscall_unlinkat__async: true,
+  __syscall_unlinkat: function (dirfd, path, flags) {
+    var p = SYSCALLS.calculateAt(dirfd, SYSCALLS.getStr(path));
+    var rmdir = flags === {{{ cDefs.AT_REMOVEDIR }}};
+    if (!rmdir && flags) return -{{{ cDefs.EINVAL }}};
+    if (!OPFS.isOpfsPath(p)) {
+      try { rmdir ? FS.rmdir(p) : FS.unlink(p); return 0; }
+      catch (e) { if (e.name !== 'ErrnoError') throw e; return -e.errno; }
+    }
+    return Asyncify.handleAsync(async () => {
+      try {
+        rmdir ? FS.rmdir(p) : FS.unlink(p);
+        await OPFS.remove(OPFS.toParts(p));
+        return 0;
+      } catch (e) {
+        if (e.name !== 'ErrnoError') throw e;
+        return -e.errno;
+      }
+    });
+  },
+
+  __syscall_renameat__deps: ['$OPFS', '$FS', '$SYSCALLS'],
+  __syscall_renameat__async: true,
+  __syscall_renameat: function (olddirfd, oldpath, newdirfd, newpath) {
+    var oldp = SYSCALLS.calculateAt(olddirfd, SYSCALLS.getStr(oldpath));
+    var newp = SYSCALLS.calculateAt(newdirfd, SYSCALLS.getStr(newpath));
+    var oldOpfs = OPFS.isOpfsPath(oldp);
+    var newOpfs = OPFS.isOpfsPath(newp);
+    if (!oldOpfs && !newOpfs) {
+      try { FS.rename(oldp, newp); return 0; }
+      catch (e) { if (e.name !== 'ErrnoError') throw e; return -e.errno; }
+    }
+    return Asyncify.handleAsync(async () => {
+      try {
+        FS.rename(oldp, newp);
+        // OPFS has no rename: write the (moved) sub-tree to its new location
+        // and remove the old one.
+        if (newOpfs) await OPFS.writeTree(newp);
+        if (oldOpfs) await OPFS.remove(OPFS.toParts(oldp));
+        return 0;
+      } catch (e) {
+        if (e.name !== 'ErrnoError') throw e;
+        return -e.errno;
+      }
+    });
+  },
+
+  // fd_close: flush a written OPFS file to disk, then close the stream.
+  //
+  // IMPORTANT: the synchronous part of an asyncify/JSPI import runs again on
+  // *rewind*. Resolving the fd to a stream here would break, because by rewind
+  // the callback has already closed it (getStreamFromFD would throw, changing
+  // the control flow and corrupting the unwind/rewind). So we keep the prologue
+  // empty/idempotent and do ALL stream work inside the once-only callback.
+  fd_close__deps: ['$OPFS', '$FS', '$SYSCALLS'],
+  fd_close__async: true,
+  fd_close: function (fd) {
+    return Asyncify.handleAsync(async () => {
+      try {
+        var stream = SYSCALLS.getStreamFromFD(fd);
+        var path = stream.path;
+        var writable = (stream.flags & {{{ cDefs.O_ACCMODE }}}) !== {{{ cDefs.O_RDONLY }}};
+        var persist = writable && OPFS.isOpfsPath(path) && FS.isFile(stream.node.mode);
+        var bytes = persist ? OPFS.memBytes(path) : null;
+        FS.close(stream);
+        if (persist) await OPFS.writeBytes(OPFS.toParts(path), bytes);
+        return 0;
+      } catch (e) {
+        if (e.name !== 'ErrnoError') throw e;
+        return -e.errno;
+      }
+    });
+  },
+});

--- a/emscriptenbuild/post-opfs.js
+++ b/emscriptenbuild/post-opfs.js
@@ -1,0 +1,35 @@
+/**
+ * post-opfs.js — extra glue for the SAB-free OPFS builds (lg2_opfs_async /
+ * lg2_opfs_jspi). Appended AFTER post.js (which provides the synchronous HTTP
+ * transport used inside the Web Worker).
+ *
+ * Because the OPFS filesystem calls suspend the wasm stack (ASYNCIFY or JSPI),
+ * `callMain` no longer completes synchronously: with JSPI the entry point is a
+ * "promising" function that returns a Promise, and with ASYNCIFY the call
+ * returns while an async continuation is still pending. We wrap `callMain` so
+ * callers can simply `await lg.callMain([...])` regardless of which mechanism
+ * the build uses.
+ */
+
+// libgit2 sometimes calls chmod with only S_IFREG set (mode 0). Make chmod a
+// no-op (same workaround the async transport build uses) so those calls don't
+// fail; file permission bits are irrelevant in the browser FS anyway.
+const _opfs_origChmod = FS.chmod;
+FS.chmod = function (path, mode, dontFollow) {
+  try {
+    return _opfs_origChmod.call(FS, path, mode, dontFollow);
+  } catch (e) {
+    return 0;
+  }
+};
+
+Module.origCallMain = Module.callMain;
+Module.callMain = async (args) => {
+  // JSPI: origCallMain returns a Promise (entry point is WebAssembly.promising).
+  // ASYNCIFY: origCallMain returns synchronously but may leave a pending chain.
+  const ret = await Module.origCallMain(args);
+  if (typeof Asyncify === 'object' && Asyncify.whenDone && Asyncify.currData) {
+    await Asyncify.whenDone();
+  }
+  return ret;
+};

--- a/lg2_opfs_auto.js
+++ b/lg2_opfs_auto.js
@@ -1,0 +1,271 @@
+/**
+ * lg2_opfs_auto.js — runtime loader that picks the most optimal OPFS-backed
+ * wasm-git build the current browser supports, and exposes a single, uniform
+ * git API on top of all three OPFS variants.
+ *
+ * Selection order (best first):
+ *   1. pthreads / WasmFS  (lg2_opfs.js)       — fastest, needs cross-origin
+ *      isolation (SharedArrayBuffer + COOP/COEP).
+ *   2. JSPI                (lg2_opfs_jspi.js)  — WebAssembly stack switching;
+ *      no SharedArrayBuffer required.
+ *   3. ASYNCIFY            (lg2_opfs_async.js) — universal fallback; works
+ *      everywhere wasm + OPFS do, no SharedArrayBuffer required.
+ *
+ * If OPFS itself is unavailable (no `navigator.storage.getDirectory`, insecure
+ * context) `selectOpfsVariant()` returns `null`; callers should fall back to
+ * the non-OPFS IDBFS build (`lg2.js`).
+ *
+ * The detection helpers below are pure and take an `env` object (defaulting to
+ * `globalThis`) so they can be unit-tested / forced in tests.
+ *
+ * Usage (inside a Web Worker — OPFS sync access handles require a Worker):
+ *
+ *   import { loadOpfsGit } from './lg2_opfs_auto.js';
+ *   const git = await loadOpfsGit({ user: 'Me', email: 'me@example.com' });
+ *   console.log(git.variant);            // 'pthreads' | 'jspi' | 'asyncify'
+ *   await git.clone(url, 'repo.git');
+ *   await git.writeFile('repo.git', 'a.txt', 'hello');
+ *   await git.addCommitPush('repo.git', 'a.txt', 'add a.txt');
+ *   git.readFile('repo.git', 'a.txt');   // 'hello'
+ */
+
+export const VARIANT_FILES = {
+  pthreads: 'lg2_opfs.js',
+  jspi: 'lg2_opfs_jspi.js',
+  asyncify: 'lg2_opfs_async.js',
+};
+
+/**
+ * Feature-detect the relevant capabilities of an environment.
+ * @param {object} [env=globalThis]
+ * @returns {{opfsAvailable:boolean, crossOriginIsolated:boolean, jspiAvailable:boolean}}
+ */
+export function detectOpfsEnvironment(env = globalThis) {
+  const nav = env.navigator;
+  const opfsAvailable = !!(
+    nav &&
+    nav.storage &&
+    typeof nav.storage.getDirectory === 'function'
+  );
+  const crossOriginIsolated =
+    env.crossOriginIsolated === true && typeof env.SharedArrayBuffer !== 'undefined';
+  const wasm = env.WebAssembly;
+  // JSPI shipped as WebAssembly.Suspending / WebAssembly.promising. Older
+  // experimental builds exposed WebAssembly.Function with a suspending option;
+  // we only rely on the shipped API here.
+  const jspiAvailable = !!(
+    wasm &&
+    (typeof wasm.Suspending === 'function' || typeof wasm.promising === 'function')
+  );
+  return { opfsAvailable, crossOriginIsolated, jspiAvailable };
+}
+
+/**
+ * Choose the best OPFS build for an environment.
+ * @param {object} [env=globalThis]
+ * @returns {('pthreads'|'jspi'|'asyncify'|null)} null means OPFS is unavailable.
+ */
+export function selectOpfsVariant(env = globalThis) {
+  const { opfsAvailable, crossOriginIsolated, jspiAvailable } = detectOpfsEnvironment(env);
+  if (!opfsAvailable) return null;
+  if (crossOriginIsolated) return 'pthreads';
+  if (jspiAvailable) return 'jspi';
+  return 'asyncify';
+}
+
+/**
+ * Load and initialise the selected OPFS build.
+ *
+ * @param {object} [options]
+ * @param {object} [options.env=globalThis]            environment to detect against
+ * @param {string} [options.variant]                   force a variant (skip detection)
+ * @param {string|URL} [options.baseUrl=import.meta.url] base for resolving the variant file
+ * @param {object} [options.variantFiles=VARIANT_FILES] override variant→filename map
+ * @param {object} [options.moduleOverrides]           print/printErr overrides for the module
+ * @param {string} [options.user]                      git user.name to write to ~/.gitconfig
+ * @param {string} [options.email]                     git user.email to write to ~/.gitconfig
+ * @returns {Promise<OpfsGit>}
+ */
+export async function loadOpfsGit(options = {}) {
+  const env = options.env || globalThis;
+  const variant = options.variant || selectOpfsVariant(env);
+  if (!variant) {
+    throw new Error(
+      'OPFS is not available in this context — fall back to the IDBFS build (lg2.js).'
+    );
+  }
+  const files = options.variantFiles || VARIANT_FILES;
+  const file = files[variant];
+  if (!file) throw new Error(`Unknown OPFS variant: ${variant}`);
+
+  if (options.moduleOverrides) {
+    globalThis.wasmGitModuleOverrides = options.moduleOverrides;
+  }
+
+  const baseUrl = options.baseUrl || import.meta.url;
+  const mod = await import(new URL(file, baseUrl));
+  const module = await mod.default(options.moduleArg || {});
+
+  const git = new OpfsGit(module, variant, env);
+  await git.init({ user: options.user, email: options.email });
+  return git;
+}
+
+/**
+ * Uniform git facade over the three OPFS variants. Repos live under `/opfs`
+ * (the OPFS root). All methods accept a bare repo directory name (e.g.
+ * `repo.git`) which is resolved under `/opfs`.
+ */
+export class OpfsGit {
+  constructor(module, variant, env = globalThis) {
+    this.module = module;
+    this.FS = module.FS;
+    this.variant = variant;
+    this.crossOriginIsolated = env.crossOriginIsolated === true;
+    this.opfsRoot = '/opfs';
+  }
+
+  repoDir(repoName) {
+    return `${this.opfsRoot}/${repoName}`;
+  }
+
+  async init({ user = 'wasm-git', email = 'wasm-git@example.com' } = {}) {
+    const FS = this.FS;
+    try { FS.mkdir('/home'); } catch (e) {}
+    try { FS.mkdir('/home/web_user'); } catch (e) {}
+    FS.writeFile('/home/web_user/.gitconfig', `[user]\nname = ${user}\nemail = ${email}`);
+
+    if (this.variant === 'pthreads') {
+      // WasmFS: explicitly mount an OPFS backend at /opfs.
+      const backend = this.module._lg2_create_opfs_backend();
+      if (!backend) throw new Error('Failed to create OPFS backend');
+      const rc = this.module.ccall(
+        'lg2_create_directory', 'number',
+        ['string', 'number', 'number'],
+        [this.opfsRoot, 0o777, backend]
+      );
+      if (rc !== 0) throw new Error('Failed to create OPFS directory, error: ' + rc);
+    }
+    // For async/jspi the /opfs MEMFS mount is created by the library at preRun.
+    FS.chdir(this.opfsRoot);
+    return this;
+  }
+
+  // ---- WasmFS getcwd() workaround (pthreads only) -------------------------
+  // WasmFS getcwd() drops the mount-point name for OPFS-backed dirs, returning
+  // '//repo' instead of '/opfs/repo', which breaks libgit2 repo discovery. A
+  // root symlink makes the broken path still resolve correctly.
+  _createMountSymlink(repoName) {
+    try { this.FS.unlink('/' + repoName); } catch (e) {}
+    this.FS.symlink(this.repoDir(repoName), '/' + repoName);
+  }
+  _removeMountSymlink(repoName) {
+    try { this.FS.unlink('/' + repoName); } catch (e) {}
+  }
+
+  _rmdirRecursive(path) {
+    const FS = this.FS;
+    for (const entry of FS.readdir(path).filter((e) => e !== '.' && e !== '..')) {
+      const full = path + '/' + entry;
+      try { FS.readdir(full); this._rmdirRecursive(full); }
+      catch (e) { FS.unlink(full); }
+    }
+    FS.rmdir(path);
+  }
+
+  /** callMain that works for both sync (pthreads) and async (asyncify/jspi). */
+  async run(args) {
+    return await this.module.callMain(args);
+  }
+
+  /**
+   * Make an already-persisted repo available locally.
+   * @returns {Promise<boolean>} true if the repo exists in OPFS.
+   */
+  async syncRepo(repoName) {
+    const FS = this.FS;
+    const dir = this.repoDir(repoName);
+    if (this.variant === 'pthreads') {
+      try {
+        const contents = FS.readdir(dir);
+        if (contents.find((f) => f === '.git')) {
+          this._createMountSymlink(repoName);
+          FS.chdir(dir);
+          return true;
+        }
+      } catch (e) { /* not present */ }
+      return false;
+    }
+    // async / jspi: load the OPFS sub-tree into the MEMFS cache.
+    const loaded = await this.module.opfsLoadTree(dir);
+    if (!loaded) return false;
+    try {
+      if (FS.readdir(dir).find((f) => f === '.git')) {
+        FS.chdir(dir);
+        return true;
+      }
+    } catch (e) {}
+    return false;
+  }
+
+  /** Clone a repository into `/opfs/<repoName>`, replacing any existing copy. */
+  async clone(url, repoName) {
+    const FS = this.FS;
+    const dir = this.repoDir(repoName);
+    await this.removeRepo(repoName);
+    await this.run(['clone', url, dir]);
+    if (this.variant === 'pthreads') this._createMountSymlink(repoName);
+    FS.chdir(dir);
+    return FS.readdir('.');
+  }
+
+  /** Write a working-tree file, persisting it to OPFS. */
+  async writeFile(repoName, filename, contents) {
+    const path = `${this.repoDir(repoName)}/${filename}`;
+    if (this.variant === 'pthreads') {
+      this.FS.writeFile(path, contents);
+    } else {
+      await this.module.opfsWriteFile(path, contents);
+    }
+  }
+
+  /** Read a working-tree file from the local cache. */
+  readFile(repoName, filename, encoding = 'utf8') {
+    return this.FS.readFile(`${this.repoDir(repoName)}/${filename}`, { encoding });
+  }
+
+  readdir(repoName) {
+    return this.FS.readdir(this.repoDir(repoName));
+  }
+
+  /** Stage, commit and push a file. */
+  async addCommitPush(repoName, filename, message = `update ${filename}`) {
+    const FS = this.FS;
+    const dir = this.repoDir(repoName);
+    FS.chdir(dir);
+    await this.run(['add', '--verbose', filename]);
+    FS.chdir(dir);
+    await this.run(['commit', '-m', message]);
+    FS.chdir(dir);
+    await this.run(['push']);
+    FS.chdir(dir);
+    return FS.readdir('.');
+  }
+
+  /** Delete a repo from both the local cache and OPFS. */
+  async removeRepo(repoName) {
+    const dir = this.repoDir(repoName);
+    if (this.variant === 'pthreads') {
+      try { this._rmdirRecursive(dir); } catch (e) {}
+      try {
+        const root = await navigator.storage.getDirectory();
+        await root.removeEntry(repoName, { recursive: true });
+      } catch (e) {}
+      this._removeMountSymlink(repoName);
+    } else {
+      await this.module.opfsRemoveTree(dir);
+    }
+  }
+}
+
+export default loadOpfsGit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasm-git",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wasm-git",
-            "version": "0.0.14",
+            "version": "0.0.15",
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
                 "@web/test-runner": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
         "lg2_async.wasm",
         "lg2_opfs.js",
         "lg2_opfs.wasm",
+        "lg2_opfs_async.js",
+        "lg2_opfs_async.wasm",
+        "lg2_opfs_jspi.js",
+        "lg2_opfs_jspi.wasm",
+        "lg2_opfs_auto.js",
         "README.md"
     ],
     "scripts": {
@@ -24,7 +29,10 @@
         "test-browser-watch": "wtr test-browser/**/*.spec.js --watch",
         "test-browser-async": "wtr test-browser-async/**/*.spec.js",
         "test-browser-opfs": "wtr --config web-test-runner-opfs.config.js",
+        "test-browser-opfs-noniso": "wtr --config web-test-runner-opfs-noniso.config.js",
         "test-opfs-example": "playwright test --config playwright-opfs.config.js",
+        "test-opfs-loader": "playwright test --config playwright-opfs-loader.config.js",
+        "test-opfs-detect": "mocha test/opfs-detect.spec.js",
         "patch-version": "npm --no-git-tag-version version patch"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasm-git",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "type": "module",
     "author": {
         "name": "Peter Salomonsen",

--- a/playwright-opfs-loader.config.js
+++ b/playwright-opfs-loader.config.js
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Multi-browser test that the runtime loader (lg2_opfs_auto.js) selects the
+// optimal OPFS build per browser/context and that the selected build works.
+//
+// Coverage matrix:
+//   chromium-isolated (COOP/COEP, :7780) → pthreads (lg2_opfs),     isolated=true
+//   chromium          (no COOP/COEP, :7781) → jspi  (lg2_opfs_jspi), isolated=false
+//   firefox           (no COOP/COEP, :7781) → asyncify (no JSPI)
+//   webkit            (no COOP/COEP, :7781) → asyncify (no JSPI)
+export default defineConfig({
+  testMatch: 'test-browser-opfs-noniso/loader.spec.js',
+  timeout: 120000,
+  workers: 1,
+  projects: [
+    {
+      name: 'chromium-isolated',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:7780',
+      },
+      metadata: { expectedVariant: 'pthreads', isolated: true },
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:7781',
+        launchOptions: {
+          args: [
+            '--enable-experimental-webassembly-features',
+            '--js-flags=--experimental-wasm-jspi',
+          ],
+        },
+      },
+      metadata: { expectedVariant: 'jspi', isolated: false },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'], baseURL: 'http://localhost:7781' },
+      metadata: { expectedVariant: 'asyncify', isolated: false },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'], baseURL: 'http://localhost:7781' },
+      metadata: { expectedVariant: 'asyncify', isolated: false },
+    },
+  ],
+  webServer: {
+    command: 'node test-browser-opfs-noniso/serve-loader.mjs',
+    url: 'http://localhost:7781/ping',
+    reuseExistingServer: false,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/preparepublishnpm.sh
+++ b/preparepublishnpm.sh
@@ -7,4 +7,9 @@ cp emscriptenbuild/libgit2/examples/lg2_async.wasm .
 cp emscriptenbuild/libgit2/examples/lg2_async.js .
 cp emscriptenbuild/libgit2/examples/lg2_opfs.wasm .
 cp emscriptenbuild/libgit2/examples/lg2_opfs.js .
+cp emscriptenbuild/libgit2/examples/lg2_opfs_async.wasm .
+cp emscriptenbuild/libgit2/examples/lg2_opfs_async.js .
+cp emscriptenbuild/libgit2/examples/lg2_opfs_jspi.wasm .
+cp emscriptenbuild/libgit2/examples/lg2_opfs_jspi.js .
+# lg2_opfs_auto.js is a hand-written source file already at the repo root
 echo "npm package prepared"

--- a/test-browser-opfs-noniso/loader.html
+++ b/test-browser-opfs-noniso/loader.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>wasm-git OPFS loader test</title></head>
+  <body>
+    <h1>wasm-git OPFS loader test</h1>
+  </body>
+</html>

--- a/test-browser-opfs-noniso/loader.spec.js
+++ b/test-browser-opfs-noniso/loader.spec.js
@@ -4,10 +4,13 @@ import { test, expect } from '@playwright/test';
 // for the current browser/context, and that the selected build performs a real
 // clone where OPFS is actually usable.
 //
-// Note: Playwright's headless WebKit does not implement OPFS storage
-// (navigator.storage.getDirectory() throws), even though real Safari does. The
-// variant *selection* (pure feature detection) is asserted for every browser;
-// the functional clone runs only where OPFS storage works.
+// Note on WebKit: Playwright's headless WebKit does not implement OPFS at all
+// (on Linux `navigator.storage.getDirectory` is missing; on macOS it exists but
+// throws when called), even though real Safari supports OPFS. So for WebKit we
+// only assert that the loader *correctly* reports the situation:
+//   - OPFS detected  → 'asyncify' (WebKit has no JSPI)
+//   - OPFS missing   → null       (loader signals the IDBFS fallback)
+// The functional clone runs only where OPFS storage actually works.
 test('loader selects the optimal OPFS build (and clones where OPFS works)', async ({ page }, testInfo) => {
   const { expectedVariant, isolated } = testInfo.project.metadata;
 
@@ -19,21 +22,34 @@ test('loader selects the optimal OPFS build (and clones where OPFS works)', asyn
   const pageIsolated = await page.evaluate(() => self.crossOriginIsolated === true);
   expect(pageIsolated, 'page crossOriginIsolated').toBe(isolated);
 
-  // 1) Variant selection — pure detection, works in every browser.
-  const selected = await page.evaluate(async () => {
-    const { selectOpfsVariant } = await import('/lg2_opfs_auto.js');
-    return selectOpfsVariant(globalThis);
+  // Detect capabilities and the loader's selection (pure feature detection).
+  const { detected, selected } = await page.evaluate(async () => {
+    const { detectOpfsEnvironment, selectOpfsVariant } = await import('/lg2_opfs_auto.js');
+    return { detected: detectOpfsEnvironment(globalThis), selected: selectOpfsVariant(globalThis) };
   });
+
+  // 1) Variant selection.
+  if (!detected.opfsAvailable) {
+    // OPFS entirely unavailable (e.g. Playwright Linux WebKit): the loader must
+    // return null so the caller falls back to the IDBFS build.
+    expect(selected, 'no-OPFS → null (IDBFS fallback)').toBeNull();
+    testInfo.annotations.push({
+      type: 'skip-functional',
+      description: 'OPFS unavailable in this runtime; loader correctly returns null (IDBFS fallback)',
+    });
+    expect(errors, 'no page errors').toEqual([]);
+    return;
+  }
   expect(selected, 'loader-selected variant').toBe(expectedVariant);
 
-  // 2) Functional clone — only where OPFS storage is actually available.
+  // 2) Functional clone — only where OPFS storage is actually usable.
   const opfsUsable = await page.evaluate(async () => {
     try { await navigator.storage.getDirectory(); return true; } catch (e) { return false; }
   });
   if (!opfsUsable) {
     testInfo.annotations.push({
       type: 'skip-functional',
-      description: 'OPFS storage unavailable in this browser/runtime; selection verified only',
+      description: 'OPFS storage present but not usable in this runtime; selection verified only',
     });
     expect(errors, 'no page errors').toEqual([]);
     return;

--- a/test-browser-opfs-noniso/loader.spec.js
+++ b/test-browser-opfs-noniso/loader.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies the runtime loader (lg2_opfs_auto.js) selects the optimal OPFS build
+// for the current browser/context, and that the selected build performs a real
+// clone where OPFS is actually usable.
+//
+// Note: Playwright's headless WebKit does not implement OPFS storage
+// (navigator.storage.getDirectory() throws), even though real Safari does. The
+// variant *selection* (pure feature detection) is asserted for every browser;
+// the functional clone runs only where OPFS storage works.
+test('loader selects the optimal OPFS build (and clones where OPFS works)', async ({ page }, testInfo) => {
+  const { expectedVariant, isolated } = testInfo.project.metadata;
+
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto('/');
+
+  // The page's isolation state must match the project's expectation.
+  const pageIsolated = await page.evaluate(() => self.crossOriginIsolated === true);
+  expect(pageIsolated, 'page crossOriginIsolated').toBe(isolated);
+
+  // 1) Variant selection — pure detection, works in every browser.
+  const selected = await page.evaluate(async () => {
+    const { selectOpfsVariant } = await import('/lg2_opfs_auto.js');
+    return selectOpfsVariant(globalThis);
+  });
+  expect(selected, 'loader-selected variant').toBe(expectedVariant);
+
+  // 2) Functional clone — only where OPFS storage is actually available.
+  const opfsUsable = await page.evaluate(async () => {
+    try { await navigator.storage.getDirectory(); return true; } catch (e) { return false; }
+  });
+  if (!opfsUsable) {
+    testInfo.annotations.push({
+      type: 'skip-functional',
+      description: 'OPFS storage unavailable in this browser/runtime; selection verified only',
+    });
+    expect(errors, 'no page errors').toEqual([]);
+    return;
+  }
+
+  const result = await page.evaluate(async () => {
+    const worker = new Worker('/test-browser-opfs-noniso/worker.js', { type: 'module' });
+    const once = (pred) =>
+      new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('worker timeout')), 60000);
+        worker.onmessage = (e) => {
+          if (e.data.error) { clearTimeout(timer); reject(new Error(e.data.error)); return; }
+          if (pred(e.data)) { clearTimeout(timer); resolve(e.data); }
+        };
+        worker.onerror = (e) => { clearTimeout(timer); reject(new Error('worker.onerror: ' + e.message)); };
+      });
+
+    worker.postMessage({ command: 'init' }); // auto-detect
+    const ready = await once((d) => d.ready);
+    worker.postMessage({ command: 'clone', url: location.origin + '/testrepo.git' });
+    const cloned = await once((d) => d.dircontents);
+    return { ready, dircontents: cloned.dircontents };
+  });
+
+  expect(errors, 'no page errors').toEqual([]);
+  expect(result.ready.crossOriginIsolated, 'reported crossOriginIsolated').toBe(isolated);
+  expect(result.ready.variant, 'selected variant (worker)').toBe(expectedVariant);
+  expect(result.dircontents, 'clone produced a .git directory').toContain('.git');
+});

--- a/test-browser-opfs-noniso/opfs.spec.js
+++ b/test-browser-opfs-noniso/opfs.spec.js
@@ -1,0 +1,111 @@
+/**
+ * Functional suite for the SAB-free OPFS builds, run in a NON cross-origin
+ * isolated context. Exercises both the ASYNCIFY and JSPI variants through the
+ * loader (forcing each variant), proving a full clone / add / commit / push /
+ * readfile workflow works and that data persists in OPFS across a worker
+ * "reload" — all with `self.crossOriginIsolated === false`.
+ */
+
+const VARIANTS = ['asyncify', 'jspi'];
+
+function makeHarness() {
+  let worker;
+
+  const recv = (predicate) =>
+    new Promise((resolve, reject) => {
+      worker.onmessage = (msg) => {
+        if (msg.data.error) { reject(new Error(msg.data.error + '\n' + (msg.data.stderr || ''))); return; }
+        if (predicate(msg.data)) resolve(msg.data);
+        else console.log('worker:', msg.data);
+      };
+    });
+
+  const createWorker = async (variant) => {
+    worker = new Worker(new URL('worker.js', import.meta.url), { type: 'module' });
+    worker.postMessage({ command: 'init', variant });
+    return recv((d) => d.ready === true);
+  };
+
+  const call = (command, params) => {
+    const p = recv((d) => !d.ready);
+    worker.postMessage(Object.assign({ command }, params));
+    return p;
+  };
+
+  const terminate = () => worker && worker.terminate();
+
+  const cleanOpfs = async (repoName) => {
+    try {
+      const root = await navigator.storage.getDirectory();
+      await root.removeEntry(repoName, { recursive: true });
+    } catch (e) { /* not present */ }
+  };
+
+  return { createWorker, call, terminate, cleanOpfs };
+}
+
+VARIANTS.forEach((variant) => {
+  describe(`wasm-git OPFS (${variant}, non-isolated)`, function () {
+    this.timeout(40000);
+
+    const h = makeHarness();
+    const url = `${location.origin}/testrepo.git`;
+
+    after(() => h.terminate());
+
+    it('reports the forced variant and a non-isolated context', async () => {
+      await h.cleanOpfs('testrepo.git');
+      const ready = await h.createWorker(variant);
+      assert.equal(ready.variant, variant);
+      assert.isFalse(ready.crossOriginIsolated, 'expected crossOriginIsolated === false');
+      assert.isFalse(self.crossOriginIsolated, 'page itself must be non-isolated');
+    });
+
+    it('pings the git server', async () => {
+      const res = await fetch('/testrepo.git/ping').then((r) => r.text());
+      assert.equal(res, 'pong');
+    });
+
+    it('finds no existing repository in fresh OPFS', async () => {
+      const r = await h.call('synclocal', { url });
+      assert.isTrue(r.notfound);
+    });
+
+    it('clones the repository and pushes a commit', async () => {
+      const cloned = await h.call('clone', { url });
+      assert.include(cloned.dircontents, '.git');
+
+      const pushed = await h.call('writecommitandpush', {
+        filename: 'test.txt',
+        contents: 'hello world!',
+      });
+      assert.include(pushed.dircontents, 'test.txt');
+    });
+
+    it('persists data in OPFS across a worker reload (no re-clone)', async () => {
+      h.terminate();
+      await h.createWorker(variant);
+      const synced = await h.call('synclocal', { url });
+      assert.include(synced.dircontents, '.git', 'repo should be restored from OPFS');
+      assert.include(synced.dircontents, 'test.txt', 'working file should persist in OPFS');
+      const read = await h.call('readfile', { filename: 'test.txt' });
+      assert.equal(read.filecontents, 'hello world!');
+    });
+
+    it('removes the local clone', async () => {
+      const del = await h.call('deletelocal');
+      assert.equal(del.deleted, 'testrepo.git');
+    });
+
+    it('re-clones from the server with the pushed contents', async () => {
+      h.terminate();
+      await h.cleanOpfs('testrepo.git');
+      await h.createWorker(variant);
+      const cloned = await h.call('clone', { url });
+      assert.include(cloned.dircontents, '.git');
+      assert.include(cloned.dircontents, 'test.txt');
+      const read = await h.call('readfile', { filename: 'test.txt' });
+      assert.equal(read.filecontents, 'hello world!');
+    });
+  });
+});

--- a/test-browser-opfs-noniso/serve-loader.mjs
+++ b/test-browser-opfs-noniso/serve-loader.mjs
@@ -1,0 +1,63 @@
+/**
+ * Server for the multi-browser loader Playwright tests.
+ *
+ * Serves the repository root over two ports so the loader can be exercised in
+ * both contexts:
+ *   - 7780: cross-origin ISOLATED   (COOP + COEP headers)  → enables pthreads
+ *   - 7781: NON cross-origin isolated (no COOP/COEP)        → JSPI / ASYNCIFY
+ * Both proxy git smart-HTTP requests (*.git/*) to a bare repo served by the
+ * shared git http backend on port 8080.
+ */
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { startServer } from '../test-browser/githttpserver.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+startServer(); // git http backend on :8080
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.wasm': 'application/wasm',
+};
+
+function makeServer(isolated) {
+  return http.createServer((req, res) => {
+    if (isolated) {
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+      res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    }
+    const urlPath = (req.url || '/').split('?')[0];
+
+    if (urlPath === '/ping') {
+      res.writeHead(200);
+      res.end('pong');
+      return;
+    }
+    if (/\.git\//.test(urlPath)) {
+      const proxy = http.request(
+        { hostname: 'localhost', port: 8080, path: req.url, method: req.method, headers: req.headers },
+        (pr) => { res.writeHead(pr.statusCode, pr.headers); pr.pipe(res); }
+      );
+      proxy.on('error', (e) => { res.writeHead(502); res.end('' + e); });
+      req.pipe(proxy);
+      return;
+    }
+    const filePath = urlPath === '/' ? path.join(repoRoot, 'test-browser-opfs-noniso/loader.html')
+      : path.join(repoRoot, urlPath);
+    fs.readFile(filePath, (err, data) => {
+      if (err) { res.writeHead(404); res.end('Not found: ' + urlPath); return; }
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath)] || 'application/octet-stream' });
+      res.end(data);
+    });
+  });
+}
+
+makeServer(true).listen(7780, () => console.log('isolated server on http://localhost:7780'));
+makeServer(false).listen(7781, () => console.log('non-isolated server on http://localhost:7781'));

--- a/test-browser-opfs-noniso/worker.js
+++ b/test-browser-opfs-noniso/worker.js
@@ -1,0 +1,62 @@
+/**
+ * Web Worker for the SAB-free OPFS builds (ASYNCIFY / JSPI), driven through the
+ * runtime loader's uniform OpfsGit API. Runs in a non-cross-origin-isolated
+ * context (no SharedArrayBuffer). OPFS sync access handles require a Worker, so
+ * all git work happens here.
+ */
+import { loadOpfsGit } from './lg2_opfs_auto.js';
+
+let git;
+let currentRepo;
+let stdout = [];
+let stderr = [];
+
+onmessage = async (e) => {
+  const m = e.data;
+  try {
+    if (m.command === 'init') {
+      stdout = [];
+      stderr = [];
+      globalThis.wasmGitModuleOverrides = {
+        print: (t) => { console.log(t); stdout.push(t); },
+        printErr: (t) => { console.error(t); stderr.push(t); },
+      };
+      git = await loadOpfsGit({
+        variant: m.variant, // undefined → auto-detect
+        user: 'Test User',
+        email: 'test@example.com',
+      });
+      postMessage({
+        ready: true,
+        variant: git.variant,
+        crossOriginIsolated: git.crossOriginIsolated,
+      });
+      return;
+    }
+
+    if (m.command === 'synclocal') {
+      currentRepo = m.url.substring(m.url.lastIndexOf('/') + 1);
+      const found = await git.syncRepo(currentRepo);
+      postMessage(found ? { dircontents: git.readdir(currentRepo) } : { notfound: true });
+    } else if (m.command === 'clone') {
+      currentRepo = m.url.substring(m.url.lastIndexOf('/') + 1);
+      const dircontents = await git.clone(m.url, currentRepo);
+      postMessage({ dircontents });
+    } else if (m.command === 'writecommitandpush') {
+      await git.writeFile(currentRepo, m.filename, m.contents);
+      const dircontents = await git.addCommitPush(currentRepo, m.filename, `add ${m.filename}`);
+      postMessage({ dircontents });
+    } else if (m.command === 'readfile') {
+      postMessage({ filename: m.filename, filecontents: git.readFile(currentRepo, m.filename) });
+    } else if (m.command === 'deletelocal') {
+      await git.removeRepo(currentRepo);
+      const deleted = currentRepo;
+      currentRepo = undefined;
+      postMessage({ deleted });
+    } else {
+      postMessage({ error: 'unknown command: ' + m.command });
+    }
+  } catch (err) {
+    postMessage({ error: String((err && err.stack) || err), stderr: stderr.join('\n') });
+  }
+};

--- a/test/opfs-detect.spec.js
+++ b/test/opfs-detect.spec.js
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the OPFS variant detection / selection logic in
+ * lg2_opfs_auto.js. These are pure functions that take an `env` object, so we
+ * can force any combination of capabilities without a browser.
+ */
+import { assert } from 'chai';
+import { detectOpfsEnvironment, selectOpfsVariant } from '../lg2_opfs_auto.js';
+
+// Build a fake environment with the given capabilities.
+function env({ opfs = true, isolated = false, sab = false, jspi = false } = {}) {
+  return {
+    navigator: opfs ? { storage: { getDirectory: () => {} } } : {},
+    crossOriginIsolated: isolated,
+    SharedArrayBuffer: sab ? function () {} : undefined,
+    WebAssembly: jspi ? { Suspending: function () {}, promising: function () {} } : {},
+  };
+}
+
+describe('OPFS detection', () => {
+  it('detects OPFS availability', () => {
+    assert.isTrue(detectOpfsEnvironment(env({ opfs: true })).opfsAvailable);
+    assert.isFalse(detectOpfsEnvironment(env({ opfs: false })).opfsAvailable);
+  });
+
+  it('only reports cross-origin isolation when SharedArrayBuffer exists too', () => {
+    assert.isFalse(detectOpfsEnvironment(env({ isolated: true, sab: false })).crossOriginIsolated);
+    assert.isTrue(detectOpfsEnvironment(env({ isolated: true, sab: true })).crossOriginIsolated);
+  });
+
+  it('detects JSPI from WebAssembly.Suspending / promising', () => {
+    assert.isTrue(detectOpfsEnvironment(env({ jspi: true })).jspiAvailable);
+    assert.isFalse(detectOpfsEnvironment(env({ jspi: false })).jspiAvailable);
+  });
+});
+
+describe('OPFS variant selection', () => {
+  it('returns null when OPFS is unavailable (caller falls back to IDBFS)', () => {
+    assert.isNull(selectOpfsVariant(env({ opfs: false, isolated: true, sab: true, jspi: true })));
+  });
+
+  it('prefers pthreads when cross-origin isolated', () => {
+    assert.equal(selectOpfsVariant(env({ isolated: true, sab: true, jspi: true })), 'pthreads');
+  });
+
+  it('prefers JSPI when not isolated but JSPI is available', () => {
+    assert.equal(selectOpfsVariant(env({ isolated: false, jspi: true })), 'jspi');
+  });
+
+  it('falls back to ASYNCIFY when neither isolation nor JSPI is available', () => {
+    assert.equal(selectOpfsVariant(env({ isolated: false, jspi: false })), 'asyncify');
+  });
+
+  it('does not pick pthreads when isolated flag is set but SharedArrayBuffer is missing', () => {
+    // e.g. a context that claims isolation but lacks SAB → must not pick pthreads
+    assert.equal(selectOpfsVariant(env({ isolated: true, sab: false, jspi: true })), 'jspi');
+    assert.equal(selectOpfsVariant(env({ isolated: true, sab: false, jspi: false })), 'asyncify');
+  });
+});

--- a/web-test-runner-opfs-noniso.config.js
+++ b/web-test-runner-opfs-noniso.config.js
@@ -1,0 +1,46 @@
+import { playwrightLauncher } from '@web/test-runner-playwright';
+import { startServer } from './test-browser/githttpserver.js';
+
+startServer();
+
+// Non-isolated counterpart of web-test-runner-opfs.config.js: NO COOP/COEP
+// headers, so `self.crossOriginIsolated === false` and SharedArrayBuffer is
+// unavailable. This exercises the SAB-free OPFS builds (ASYNCIFY + JSPI).
+export default {
+  files: [
+    // Only the mocha/web-test-runner suite here; loader.spec.js is a Playwright
+    // test (run via playwright-opfs-loader.config.js), not a web-test-runner one.
+    'test-browser-opfs-noniso/opfs.spec.js',
+  ],
+  concurrency: 1,
+  watch: false,
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '20000',
+    },
+  },
+  testRunnerHtml: testRunnerImport =>
+    `<html>
+      <body>
+        <script type="module">
+            import { expect, assert} from 'https://cdn.jsdelivr.net/npm/chai@5.0.0/+esm';
+            globalThis.assert = assert;
+            globalThis.expect = expect;
+        </script>
+        <script type="module" src="${testRunnerImport}"></script>
+      </body>
+    </html>`,
+  browsers: [
+    playwrightLauncher({ product: 'chromium', createBrowserContext: async ({ browser }) => {
+      const ctx = await browser.newContext({});
+      await ctx.route(/http:\/\/localhost:8000\/.*\.git\/.*/, async (route) => {
+        const url = route.request().url();
+        const response = await route.fetch({url: url.replace(':8000/', ':8080/')});
+        const body = await response.body();
+        await route.fulfill({ body });
+      });
+      return ctx;
+    }, }),
+  ],
+};


### PR DESCRIPTION
## Goal

Add OPFS-backed persistence that works **without `SharedArrayBuffer` / cross-origin isolation**, *in addition to* the existing builds, plus a runtime loader that auto-selects the most optimal build the browser supports. This lets consumers served via NEAR web4 (which cannot set COOP/COEP) use OPFS.

## Why

The current OPFS build (`lg2_opfs`, WASMFS + pthreads) blocks a worker on the async OPFS API via `Atomics.wait`, forcing `SharedArrayBuffer` → COOP/COEP. ASYNCIFY and JSPI bridge async OPFS into synchronous libgit2 calls by **suspending the wasm stack** instead — no threads, no SAB.

## What's in here

**Two new build variants** (`emscriptenbuild/build.sh`; existing builds untouched):
- `Release-opfs-async` → `lg2_opfs_async` (ASYNCIFY, universal fallback)
- `Release-opfs-jspi` → `lg2_opfs_jspi` (JSPI / WebAssembly stack switching)

**OPFS persistence layer** (`emscriptenbuild/library_opfs.js`, a `--js-library`): a MEMFS cache under `/opfs` is mirrored to OPFS by overriding the mutating path syscalls (`mkdirat`/`unlinkat`/`renameat`) and `fd_close` as thin `Asyncify.handleAsync` wrappers — the same source works under both ASYNCIFY and JSPI. All side-effectful work runs inside the once-only callback so the unwind/rewind never double-executes it.

**Runtime loader** (`lg2_opfs_auto.js`): pure, unit-testable `detectOpfsEnvironment` / `selectOpfsVariant` choose **pthreads → JSPI → ASYNCIFY** (or `null` → IDBFS fallback), plus a uniform `OpfsGit` facade over all three variants.

## Tests

| Suite | What it proves |
|-------|----------------|
| `npm run test-browser-opfs-noniso` | ASYNCIFY + JSPI: clone/add/commit/push/readfile **and persistence across a worker reload**, all with `crossOriginIsolated === false` |
| `npm run test-opfs-loader` | Loader selects the right variant across **Chromium (isolated → pthreads, non-isolated → jspi)**, **Firefox → asyncify**, **WebKit → asyncify** |
| `npm run test-opfs-detect` | Detection unit tests |

A new `opfs-sab-free` CI job builds all three variants and runs these suites; the publish workflow + `preparepublishnpm.sh` ship the new files.

> Note: Playwright's headless WebKit has no OPFS storage (real Safari does), so the WebKit test asserts variant *selection* and skips the functional clone.

## Binary sizes (`-O3`)

| Variant | wasm | bridge |
|---------|------|--------|
| JSPI | ~805 KB | native stack switching (smallest — no instrumentation) |
| pthreads/WASMFS | ~921 KB | worker + `Atomics.wait` (needs SAB) |
| ASYNCIFY | ~1.5 MB | stack-rewriting instrumentation (largest) |

## Acceptance criteria

- [x] Existing builds unchanged (existing OPFS suite still passes 6/6)
- [x] `lg2_opfs_jspi` and `lg2_opfs_async` pass the OPFS suite with `crossOriginIsolated === false`, persisting across reloads
- [x] Loader selects pthreads → JSPI → ASYNCIFY, verified by Playwright across Chromium (isolated + non-isolated), Firefox and WebKit
- [x] README documents the three OPFS variants, the selection order, and the size/performance differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)