### PR TITLE
Test the packed npm tarball in CI; drop unusable merge_group trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,3 +132,63 @@ jobs:
           npm run test-opfs-detect
           npm run test-browser-opfs-noniso
           npm run test-opfs-loader
+  package:
+    name: "Package (tarball browser tests)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pack the npm tarball and run the browser tests against it
+        run: |
+          npm install
+          npx playwright install-deps
+          # bounded retry (same as the other jobs)
+          for i in 1 2 3; do
+            timeout -k 15 180 npx playwright install && break
+            echo "playwright install attempt $i stalled or failed; retrying..."
+            pkill -f playwright || true
+            sleep 5
+          done
+          sh setup.sh
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install 4.0.23
+          ./emsdk activate 4.0.23
+          cd ..
+          source ./emsdk/emsdk_env.sh
+          # Build every variant (no clean: differently-named outputs coexist, the
+          # same way the publish workflow builds) so preparepublishnpm.sh can copy
+          # them all to the repo root.
+          cd emscriptenbuild
+          ./build.sh Release
+          ./build.sh Release-async
+          ./build.sh Release-opfs
+          ./build.sh Release-opfs-async
+          ./build.sh Release-opfs-jspi
+          cd ..
+          set -e
+          # Produce the exact npm tarball, then run the browser suites against the
+          # EXTRACTED files — that is what consumers install, so this catches
+          # packaging mistakes (missing/renamed/corrupt files) that testing the
+          # raw build outputs would not.
+          ./preparepublishnpm.sh
+          PACKAGEFILE=`npm pack | tail -n 1`
+          rm -rf package && tar -xzf "$PACKAGEFILE"
+          cp package/lg2*.js package/lg2*.wasm package/lg2_opfs_auto.js .
+          # Point every browser test dir at the packed files at the repo root.
+          ln -sf ../lg2.js  test-browser/lg2.js
+          ln -sf ../lg2.wasm test-browser/lg2.wasm
+          ln -sf ../lg2_async.js  test-browser-async/lg2_async.js
+          ln -sf ../lg2_async.wasm test-browser-async/lg2_async.wasm
+          ln -sf ../lg2_opfs.js  test-browser-opfs/lg2_opfs.js
+          ln -sf ../lg2_opfs.wasm test-browser-opfs/lg2_opfs.wasm
+          ln -sf ../../lg2_opfs.js  examples/opfs/lg2_opfs.js
+          ln -sf ../../lg2_opfs.wasm examples/opfs/lg2_opfs.wasm
+          for f in lg2_opfs_auto.js lg2_opfs.js lg2_opfs.wasm lg2_opfs_async.js lg2_opfs_async.wasm lg2_opfs_jspi.js lg2_opfs_jspi.wasm; do
+            ln -sf ../$f test-browser-opfs-noniso/$f
+          done
+          npm run test-browser
+          npm run test-browser-async
+          npm run test-browser-opfs
+          npm run test-opfs-example
+          npm run test-browser-opfs-noniso
+          npm run test-opfs-loader

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,17 @@
 name: Publish
-# Runs on:
-#   - push to master      → real release (npm publish when the version changed)
-#   - merge_group         → pre-merge dry-run gate (when a PR is queued to merge)
-# It deliberately does NOT run on `pull_request`, so it doesn't rebuild on every
-# push to a PR; instead, with the merge queue enabled and this job marked as a
-# required check, the dry-run runs exactly once right before the PR merges.
-# Day-to-day PR validation is handled by the CI workflow (main.yml).
+# Runs only on pushes to master (actual releases): it builds every variant with
+# the latest Emscripten, runs the node test suite, and publishes to npm when the
+# version changed. Pull requests are validated by the CI workflow (main.yml),
+# which also packs the tarball and runs the browser tests against it.
 on:
   push:
     branches: [ master ]
-  merge_group:
 permissions:
   contents: read
   id-token: write
 jobs:
   default:
-    name: "Publish (build + dry-run)"
+    name: "Publish"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Tarball testing (restored, in CI)

Testing the packed tarball is valuable — it validates the artifact consumers actually `npm install`, catching packaging mistakes (missing/renamed/corrupt files) that testing raw build outputs misses. Removing it from the publish job was the wrong call.

This adds a **`Package (tarball browser tests)`** CI job that:
1. builds every variant,
2. runs `preparepublishnpm.sh` + `npm pack`,
3. extracts the tarball, and
4. runs the full browser suites (sync, async, OPFS pthreads/ASYNCIFY/JSPI, loader matrix) **against the extracted files**.

It lives in the CI workflow because playwright installs reliably there (~15s for all browsers), whereas in the publish job `npx playwright install` deterministically hangs after the chromium download — which is the actual reason the tarball tests were failing.

## Merge queue

GitHub merge queue isn't available for this repository (no `merge_queue` rule is offered in the ruleset UI), so the `merge_group` trigger I'd added to the publish workflow was inert. Removed it — Publish runs only on push to master. The pre-merge gate is the set of CI checks (now including the tarball job), which you can mark required in the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)