### PR TITLE
opfs: normalize '.'/'..' in OPFS path segments (toParts); release 0.0.16

### DIFF
--- a/emscriptenbuild/library_opfs.js
+++ b/emscriptenbuild/library_opfs.js
@@ -50,10 +50,22 @@ addToLibrary({
     isOpfsPath(p) {
       return p === OPFS.root || p.startsWith(OPFS.root + '/');
     },
-    // '/opfs/a/b' -> ['a','b']   (relative to the OPFS root directory)
+    // '/opfs/a/b' -> ['a','b']   (relative to the OPFS root directory).
+    // Normalizes the path: '' and '.' segments are dropped and '..' pops the
+    // previous segment, so callers may pass POSIX-relative bits (e.g. libgit2
+    // resolving `init .` to `/opfs/repo/.`) without producing a '.'/'' segment
+    // that OPFS would reject as a directory/file name.
     toParts(p) {
       var rel = p.slice(OPFS.root.length);
-      return rel.split('/').filter((s) => s.length > 0);
+      var parts = [];
+      var segs = rel.split('/');
+      for (var i = 0; i < segs.length; i++) {
+        var seg = segs[i];
+        if (seg === '' || seg === '.') continue;
+        if (seg === '..') { parts.pop(); continue; }
+        parts.push(seg);
+      }
+      return parts;
     },
 
     // ---- low level OPFS handle resolution (async) --------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasm-git",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wasm-git",
-            "version": "0.0.15",
+            "version": "0.0.16",
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
                 "@web/test-runner": "^0.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasm-git",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "type": "module",
     "author": {
         "name": "Peter Salomonsen",

--- a/test-browser-opfs-noniso/opfs.spec.js
+++ b/test-browser-opfs-noniso/opfs.spec.js
@@ -92,6 +92,14 @@ VARIANTS.forEach((variant) => {
       assert.equal(read.filecontents, 'hello world!');
     });
 
+    it('normalizes "." and ".." in OPFS paths (toParts regression)', async () => {
+      await h.cleanOpfs('pathnorm');
+      const r = await h.call('opfspathnormalization');
+      assert.equal(r.a, 'A', "'./' segment must be dropped");
+      assert.equal(r.b, 'B', "'..' segment must pop the previous one");
+      await h.cleanOpfs('pathnorm');
+    });
+
     it('removes the local clone', async () => {
       const del = await h.call('deletelocal');
       assert.equal(del.deleted, 'testrepo.git');

--- a/test-browser-opfs-noniso/worker.js
+++ b/test-browser-opfs-noniso/worker.js
@@ -46,6 +46,16 @@ onmessage = async (e) => {
       await git.writeFile(currentRepo, m.filename, m.contents);
       const dircontents = await git.addCommitPush(currentRepo, m.filename, `add ${m.filename}`);
       postMessage({ dircontents });
+    } else if (m.command === 'opfspathnormalization') {
+      // Regression: OPFS paths with '.'/'..' segments (e.g. from libgit2
+      // resolving `init .`) must normalize, not be passed to OPFS as '.'/''
+      // directory names. Exercises OPFS.toParts via opfsWriteFile/opfsReadFile.
+      await git.module.opfsWriteFile('/opfs/pathnorm/./a.txt', 'A');
+      await git.module.opfsWriteFile('/opfs/pathnorm/sub/../b.txt', 'B');
+      postMessage({
+        a: await git.module.opfsReadFile('/opfs/pathnorm/a.txt', 'utf8'),
+        b: await git.module.opfsReadFile('/opfs/pathnorm/b.txt', 'utf8'),
+      });
     } else if (m.command === 'readfile') {
       postMessage({ filename: m.filename, filecontents: git.readFile(currentRepo, m.filename) });
     } else if (m.command === 'deletelocal') {


### PR DESCRIPTION
## What

`OPFS.toParts` (in `library_opfs.js`) split a `/opfs/...` path and dropped only
*empty* segments. A path containing a `.` segment — e.g. libgit2 resolving
`git init .` / `git clone <url> .` to `/opfs/repo/.` — therefore reached the OPFS
API as a `.` directory/file name, which OPFS rejects with *"Name is not allowed"*.

## Fix

Normalize the path: drop `''`/`'.'` segments and let `'..'` pop the previous one.
Consumers can now pass POSIX-relative paths (like git's `.`) directly, no
absolute-path workaround needed.

## Test

Adds a regression to the non-isolated OPFS suite (run for **both** ASYNCIFY and
JSPI): `opfsWriteFile`/`opfsReadFile` with `'./'` and `'sub/../'` segments resolve
to the right files. (CI builds the OPFS variants and runs this.)

## Release

Bumps to **0.0.16** — on merge to master the publish workflow rebuilds all variants
and publishes. Consumer (Ariz-Portfolio) will switch to 0.0.16 and drop its
init/clone absolute-path workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)