### PR TITLE
syncRepo: recreate git skeleton dirs lost by files-only copies

### DIFF
--- a/lg2_opfs_auto.js
+++ b/lg2_opfs_auto.js
@@ -179,6 +179,23 @@ export class OpfsGit {
   }
 
   /**
+   * Recreate git's REQUIRED empty directories. Anything that copies a repo
+   * file-by-file (IDBFS→OPFS migrations, zip round-trips, object-store synced
+   * copies) silently loses empty directories — and libgit2 cannot create
+   * `.git/objects/pack` itself: a later fetch downloads the packfile but never
+   * indexes it, failing with "target OID for the reference doesn't exist on
+   * the repository" and no hint of the real cause (diagnosed from a real user
+   * repository that had only ever written loose objects).
+   */
+  _ensureGitSkeleton(dir) {
+    const FS = this.FS;
+    try { FS.readdir(`${dir}/.git/objects`); } catch (e) { return; }
+    for (const sub of ['objects/pack', 'objects/info', 'refs', 'refs/heads', 'refs/tags']) {
+      try { FS.mkdir(`${dir}/.git/${sub}`); } catch (e) { /* exists */ }
+    }
+  }
+
+  /**
    * Make an already-persisted repo available locally.
    * @returns {Promise<boolean>} true if the repo exists in OPFS.
    */
@@ -190,6 +207,7 @@ export class OpfsGit {
         const contents = FS.readdir(dir);
         if (contents.find((f) => f === '.git')) {
           this._createMountSymlink(repoName);
+          this._ensureGitSkeleton(dir);
           FS.chdir(dir);
           return true;
         }
@@ -201,6 +219,7 @@ export class OpfsGit {
     if (!loaded) return false;
     try {
       if (FS.readdir(dir).find((f) => f === '.git')) {
+        this._ensureGitSkeleton(dir);
         FS.chdir(dir);
         return true;
       }

--- a/test-browser-opfs-noniso/opfs.spec.js
+++ b/test-browser-opfs-noniso/opfs.spec.js
@@ -100,6 +100,17 @@ VARIANTS.forEach((variant) => {
       await h.cleanOpfs('pathnorm');
     });
 
+    it('repairs git skeleton dirs lost by files-only copies (syncRepo)', async () => {
+      await h.cleanOpfs('skelrepo');
+      const r = await h.call('skeletonrepair');
+      assert.isFalse(r.skeleton.packDirAfterMigration,
+        'the files-only migration simulation must lose .git/objects/pack');
+      assert.isTrue(r.skeleton.found, 'syncRepo should find the migrated repo');
+      assert.isTrue(r.skeleton.packDirAfterSync,
+        '.git/objects/pack must be recreated by syncRepo (libgit2 fetch cannot create it)');
+      await h.cleanOpfs('skelrepo');
+    });
+
     it('removes the local clone', async () => {
       const del = await h.call('deletelocal');
       assert.equal(del.deleted, 'testrepo.git');

--- a/test-browser-opfs-noniso/worker.js
+++ b/test-browser-opfs-noniso/worker.js
@@ -56,6 +56,43 @@ onmessage = async (e) => {
         a: await git.module.opfsReadFile('/opfs/pathnorm/a.txt', 'utf8'),
         b: await git.module.opfsReadFile('/opfs/pathnorm/b.txt', 'utf8'),
       });
+    } else if (m.command === 'skeletonrepair') {
+      // Regression: a files-only copy (e.g. an IDBFS -> OPFS migration, or any
+      // zip round-trip) loses git's EMPTY directories, and libgit2 cannot
+      // recreate .git/objects/pack itself — a later fetch then silently fails
+      // to index the downloaded pack. syncRepo must repair the skeleton.
+      const repoName = 'skelrepo';
+      const dir = git.repoDir(repoName);
+      const FS = git.FS;
+      try { await git.removeRepo(repoName); } catch (e) { /* absent */ }
+      try { FS.mkdir(dir); } catch (e) { /* exists */ }
+      FS.chdir(dir);
+      await git.run(['init', '.']);
+      await git.writeFile(repoName, 'a.txt', 'loose objects only');
+      await git.run(['add', 'a.txt']);
+      await git.run(['commit', '-m', 'c1']);
+      // Simulate the files-only migration: snapshot every FILE, delete the
+      // repo, write the files back. Empty directories vanish, exactly like a
+      // real migration.
+      const files = [];
+      const snap = (p) => {
+        for (const entry of FS.readdir(p).filter((x) => x !== '.' && x !== '..')) {
+          const full = `${p}/${entry}`;
+          try { FS.readdir(full); snap(full); }
+          catch (err) { files.push({ rel: full.substring(dir.length + 1), data: FS.readFile(full) }); }
+        }
+      };
+      snap(dir);
+      FS.chdir(git.opfsRoot);
+      await git.removeRepo(repoName);
+      for (const f of files) await git.writeFile(repoName, f.rel, f.data);
+      const exists = (p) => { try { FS.readdir(p); return true; } catch (e) { return false; } };
+      const packDirAfterMigration = exists(`${dir}/.git/objects/pack`);
+      const found = await git.syncRepo(repoName);
+      const packDirAfterSync = exists(`${dir}/.git/objects/pack`);
+      FS.chdir(git.opfsRoot);
+      try { await git.removeRepo(repoName); } catch (e) { /* cleanup */ }
+      postMessage({ skeleton: { found, packDirAfterMigration, packDirAfterSync } });
     } else if (m.command === 'readfile') {
       postMessage({ filename: m.filename, filecontents: git.readFile(currentRepo, m.filename) });
     } else if (m.command === 'deletelocal') {


### PR DESCRIPTION
Fixes #118.

## What
`OpfsGit.syncRepo()` now recreates git's required skeleton directories (`objects/pack`, `objects/info`, `refs/heads`, `refs/tags`) whenever it loads a repo that has `.git/objects` — for all three variants. JS-only; no wasm rebuild.

## Why
libgit2's fetch writes downloaded packs into `.git/objects/pack/` but never creates the directory. Any files-only copy (IDBFS→OPFS migration, zip round-trip) silently drops empty directories, and the repo then looks healthy — init/commit/push all work — until the first fetch that must index a pack, which fails with the baffling *'target OID for the reference doesn't exist on the repository'*. Hit in production by arizas/Ariz-Portfolio#76 and diagnosed by importing the actual user repository into a test browser; pre-creating the one directory fixed it.

## Test
New `skeletonrepair` regression in the non-isolated OPFS suite: builds a loose-objects-only repo, simulates the files-only migration (snapshot files → delete repo → write files back — empty dirs vanish exactly like the real thing), asserts `.git/objects/pack` is gone before `syncRepo` and present after. Runs for both asyncify and jspi; fails on both without the fix (18/18 pass with it, verified locally against the npm 0.0.16 artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)