### PR TITLE
Upgrade to libgit2 1.9.4 and Emscripten 6.0.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.23
-          ./emsdk activate 4.0.23
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           cd emscriptenbuild
@@ -50,8 +50,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.23
-          ./emsdk activate 4.0.23
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           cd emscriptenbuild
@@ -72,8 +72,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.23
-          ./emsdk activate 4.0.23
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           cd emscriptenbuild
@@ -108,8 +108,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.23
-          ./emsdk activate 4.0.23
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           # Build all three OPFS variants, copying each output to the repo root.
@@ -151,8 +151,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.23
-          ./emsdk activate 4.0.23
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           # Build every variant (no clean: differently-named outputs coexist, the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 # Runs only on pushes to master (actual releases): it builds every variant with
-# the latest Emscripten, runs the node test suite, and publishes to npm when the
-# version changed. Pull requests are validated by the CI workflow (main.yml),
+# the same pinned Emscripten as CI (main.yml), runs the node test suite, and
+# publishes to npm when the version changed. Pull requests are validated by the CI workflow (main.yml),
 # which also packs the tarball and runs the browser tests against it.
 on:
   push:
@@ -25,8 +25,8 @@ jobs:
           sh setup.sh
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install latest
-          ./emsdk activate latest
+          ./emsdk install 6.0.3
+          ./emsdk activate 6.0.3
           cd ..
           source ./emsdk/emsdk_env.sh
           cd emscriptenbuild

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The main purpose of bringing git to the browser, is to enable storage of web app
 
 ## Compatibility
 
-- **libgit2**: v1.7.1
-- **Emscripten**: Pinned to 4.0.23
+- **libgit2**: v1.9.4
+- **Emscripten**: Pinned to 6.0.3
 - **Node.js**: v18+
 - **Browsers**: Modern browsers with WebAssembly support
 
@@ -162,7 +162,7 @@ for a complete worker built on the loader.
 
 ## Prerequisites
 
-- [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html) (version 4.0.23)
+- [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html) (version 6.0.3)
 - Node.js (v18 or higher)
 - CMake
 - Make
@@ -179,8 +179,8 @@ for a complete worker built on the loader.
    ```bash
    git clone https://github.com/emscripten-core/emsdk.git
    cd emsdk
-   ./emsdk install 4.0.23
-   ./emsdk activate 4.0.23
+   ./emsdk install 6.0.3
+   ./emsdk activate 6.0.3
    source ./emsdk_env.sh
    cd ..
    ```
@@ -189,7 +189,7 @@ for a complete worker built on the loader.
    ```bash
    ./setup.sh
    ```
-   This script downloads libgit2 v1.7.1 and applies necessary patches for WebAssembly compilation.
+   This script downloads libgit2 v1.9.4 and applies necessary patches for WebAssembly compilation.
 
 4. **Build the project**
    ```bash

--- a/libgit2patchedfiles/examples/checkout.c
+++ b/libgit2patchedfiles/examples/checkout.c
@@ -13,6 +13,7 @@
  */
 
 #include "common.h"
+#include <git2/sys/errors.h>
 
 /* Define the printf format specifer to use for size_t output */
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -L https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz --output libgit2.tar.gz
+curl -L https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.4.tar.gz --output libgit2.tar.gz
 tar -xzf libgit2.tar.gz
-mv libgit2-1.7.1 libgit2
+mv libgit2-1.9.4 libgit2
 rm libgit2.tar.gz
 rm libgit2/src/libgit2/transports/http.c
 cp -r libgit2patchedfiles/examples/* libgit2/examples/


### PR DESCRIPTION
## Summary

Upgrades from libgit2 1.7.1 / Emscripten 4.0.23 to the current latest releases: **libgit2 1.9.4** and **Emscripten 6.0.3**.

Only one source change was required: libgit2 1.9.0 moved `git_error_clear` from `git2/errors.h` to `git2/sys/errors.h`, so the patched `checkout.c` now includes that header explicitly (previously it relied on an implicit declaration, which surfaced as a link-time signature mismatch). Note this makes the patched examples require libgit2 ≥ 1.8.

Everything else carried over untouched:
- the `git_smart_subtransport` API used by `emscriptenhttp.c` / `emscriptenhttp-async.c` is unchanged between 1.7.1 and 1.9.4
- `examples/common.h` is byte-identical upstream between the two versions
- all setup.sh patch targets (`http.c` removal, `GIT_PACK_FILE_MODE` / `GIT_OBJECT_FILE_MODE`) still exist
- no Emscripten 5.0/6.0 breaking change affects the flags used here (`ASYNCIFY`, `JSPI`, `WASMFS`, `EXPORT_ES6`, pthreads)

Additionally, publish.yml previously installed emsdk `latest`, meaning releases could be built with an Emscripten version CI never tested. It is now pinned to the same 6.0.3 as main.yml.

## Local verification

All five variants built with Emscripten 6.0.3 + libgit2 1.9.4:
Release, Release-async, Release-opfs, Release-opfs-async, Release-opfs-jspi.

Test results: node 6/6, browser 18/18, asyncify 10/10, OPFS 6/6. (JSPI / OPFS-loader Playwright suites not run locally — CI covers those.)

## Notes on reducing local patches (checked during this upgrade)

- **`src/util/integer.h`** — still required. Upstream 1.9.4 still selects `__builtin_uadd_overflow` (unsigned int) when `SIZE_MAX == UINT_MAX`, which mismatches wasm32's `unsigned long` `size_t`. This is upstreamable: libgit2 could use the type-generic `__builtin_add_overflow`, which would let us drop this patch in a future release.
- **C90 hack in setup.sh** — still required. `EM_ASM` refuses to compile in strict `-std=c90`, and libgit2 hard-sets `C_EXTENSIONS OFF` on the `libgit2package` target, so no cmake command-line flag can override it.
- **Example patches** — all feature additions (reset/revert commands, `checkout -b`, push-current-HEAD, `stash drop`/index, status ahead/behind counts), so they can't be dropped by upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)