### PR TITLE
publish: create a GitHub release after each npm publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
   detectonly:
     name: Detect use of .only
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Detect use of .only
@@ -17,6 +18,7 @@ jobs:
   default:
     name: "Default"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Default
@@ -40,6 +42,7 @@ jobs:
   asyncify:
     name: Asyncify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Default
@@ -62,6 +65,7 @@ jobs:
   opfs:
     name: OPFS
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: OPFS Build and Test
@@ -89,6 +93,7 @@ jobs:
   opfs-sab-free:
     name: OPFS (SAB-free ASYNCIFY + JSPI + loader)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Build SAB-free OPFS variants and test
@@ -135,6 +140,7 @@ jobs:
   package:
     name: "Package (tarball browser tests)"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Pack the npm tarball and run the browser tests against it

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
 permissions:
-  contents: read
+  contents: write # create the GitHub release + tag after a successful npm publish
   id-token: write
 jobs:
   default:
@@ -20,6 +20,8 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Default
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           npm install
           sh setup.sh
@@ -50,6 +52,10 @@ jobs:
           # always does a dry-run, never a real publish.
           if [[ "$VERSION" != "$NEWVERSION" && "$GITHUB_EVENT_NAME" = "push" ]]; then
             npm publish --provenance --access public
+            # Announce the release on GitHub so watchers/stargazers are notified;
+            # notes are generated from the PRs merged since the previous tag.
+            gh release create "v$NEWVERSION" --target "$GITHUB_SHA" \
+              --title "v$NEWVERSION" --generate-notes
           elif [[ "$VERSION" != "$NEWVERSION" ]]; then
             echo "version change is $VERSION->$NEWVERSION, event is $GITHUB_EVENT_NAME, not publishing, only dry-run"
             npm publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   default:
     name: "Publish"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Makes GitHub releases part of the release routine: after a successful `npm publish`, the publish workflow now runs `gh release create "v$NEWVERSION" --generate-notes`, tagging the released commit and notifying watchers/stargazers.

- `permissions.contents` raised from `read` to `write` (needed to create the tag + release; provenance still uses `id-token: write`).
- `GH_TOKEN` provided to the step from `github.token` for the `gh` CLI.
- Release notes are auto-generated from PRs merged since the previous tag — [v0.0.17](https://github.com/petersalomonsen/wasm-git/releases/tag/v0.0.17), created manually today, is the baseline.
- Runs only inside the real-publish branch of the version check, so dry-runs and no-change pushes never create releases.

Merging this PR does not publish or release anything (version is unchanged); the routine takes effect on the next version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)