### PR TITLE
test: force mocha to exit so a leaked handle cannot hang CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "README.md"
     ],
     "scripts": {
-        "test": "mocha test/**/*.spec.js",
+        "test": "mocha --exit test/**/*.spec.js",
         "test-browser": "wtr test-browser/**/*.spec.js",
         "test-browser-watch": "wtr test-browser/**/*.spec.js --watch",
         "test-browser-async": "wtr test-browser-async/**/*.spec.js",
@@ -32,7 +32,7 @@
         "test-browser-opfs-noniso": "wtr --config web-test-runner-opfs-noniso.config.js",
         "test-opfs-example": "playwright test --config playwright-opfs.config.js",
         "test-opfs-loader": "playwright test --config playwright-opfs-loader.config.js",
-        "test-opfs-detect": "mocha test/opfs-detect.spec.js",
+        "test-opfs-detect": "mocha --exit test/opfs-detect.spec.js",
         "patch-version": "npm --no-git-tag-version version patch"
     },
     "devDependencies": {


### PR DESCRIPTION
## What happened

The Publish job on a91915a ([run 32522680732](https://github.com/petersalomonsen/wasm-git/actions/runs/32522680732)) sat for **6 hours** and was killed by GitHub's hard limit.

The trigger was a transient network failure, not a code problem. `test/nodefs.spec.js` clones `wasm-git` from github.com over the real internet, and that transfer died at 68%:

```
net 68% ( 247 kb,   476/  699)  /  idx  40% (  285/  699)
Bad news:
 could not read from remote repository
ERROR 12: could not read from remote repository
```

The `ErrnoError errno 44` mocha reported is just the follow-on ENOENT from `FS.chdir()` into a clone directory that was never created. The CI workflow on the same commit passed in 6m27s, running the same node suite — so this was a flake, not a regression.

The damage came afterwards: mocha printed `13 passing, 1 failing` and then **never exited**. The aborted clone leaves a live handle in the emscripten module, and with no `.mocharc` and no `--exit` the event loop never drains. The job held a runner until the 6-hour cap, ending in `Terminate orphan process: pid (12095) (npm run test)`.

## The change

`--exit` on the two mocha scripts, so the process terminates once the run is over regardless of what handles third-party code left behind.

## Verification

A probe that leaks a listening socket and throws, run under a 10-second cap:

| | exit code |
|---|---|
| `mocha` | 124 — killed by the cap, still hanging |
| `mocha --exit` | 1 — exits immediately, failure preserved |

Both node suites still pass: `npm test` (14) and `npm run test-opfs-detect` (8).

## Scope

This treats the symptom. The handle leak in the aborted clone, and the fact that `nodefs.spec.js` depends on reaching github.com at all, are both still there — worth a retry wrapper or a local fixture if that test keeps flaking. What this buys is that a hang becomes an immediate visible failure instead of an occupied runner.

Complements #122, which caps every job at `timeout-minutes: 30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)